### PR TITLE
Allow binding the HTTP server to a non-loopback address

### DIFF
--- a/packages/runtime/src/server/index.ts
+++ b/packages/runtime/src/server/index.ts
@@ -27,6 +27,7 @@ import {
   type FocusUpdate,
   SERVER_PORT,
   SERVER_HOST,
+  LOCAL_CLIENT_HOST,
   PID_FILE,
   SERVER_IDLE_TIMEOUT_MS,
   STUCK_RUNNING_TIMEOUT_MS,
@@ -1915,7 +1916,10 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
 
   // --- Bootstrap ---
 
-  for (const p of allProviders) p.setupHooks(SERVER_HOST, SERVER_PORT);
+  // Local tmux hooks always curl loopback, regardless of what address
+  // the server binds to. SERVER_HOST may be 0.0.0.0 or a bridge IP to
+  // accept remote POSTs, but in-process hooks should never use that.
+  for (const p of allProviders) p.setupHooks(LOCAL_CLIENT_HOST, SERVER_PORT);
   const sidebarPresence = reconcileSidebarPresence();
   if (sidebarPresence.visible) {
     for (const { provider } of listSidebarPanesByProvider()) {

--- a/packages/runtime/src/shared.ts
+++ b/packages/runtime/src/shared.ts
@@ -2,8 +2,16 @@ import type { AgentStatus, AgentEvent } from "./contracts/agent";
 import type { MuxSessionInfo } from "./contracts/mux";
 import type { SessionFilterMode } from "./config";
 
-export const SERVER_PORT = 7391;
-export const SERVER_HOST = "127.0.0.1";
+export const SERVER_PORT = Number(process.env.OPENSESSIONS_PORT ?? 7391);
+// Bind address for the HTTP server. Override with OPENSESSIONS_HOST to
+// accept POSTs from other hosts (e.g. "0.0.0.0" to listen on all
+// interfaces, or a specific bridge IP such as "10.4.250.1"). Defaults
+// to loopback so out-of-the-box installs stay local-only.
+export const SERVER_HOST = process.env.OPENSESSIONS_HOST ?? "127.0.0.1";
+// Address that local in-process hooks use to reach the server. Always
+// loopback — remote callers should build their own URL pointing at
+// whichever address SERVER_HOST is bound to.
+export const LOCAL_CLIENT_HOST = "127.0.0.1";
 export const PID_FILE = "/tmp/opensessions.pid";
 export const SERVER_IDLE_TIMEOUT_MS = 30_000;
 export const STUCK_RUNNING_TIMEOUT_MS = 3 * 60 * 1000;


### PR DESCRIPTION
## Summary

Introduce `OPENSESSIONS_HOST` (and `OPENSESSIONS_PORT`) env vars so the server can accept POSTs from other hosts — e.g. `0.0.0.0` to listen on all interfaces, or a bridge IP like `10.4.250.1` for container networks. Defaults to `127.0.0.1` so nothing changes for local-only installs.

Local tmux hooks are explicitly routed through a new `LOCAL_CLIENT_HOST` constant (`127.0.0.1`) so they never embed the bind address in curl commands. The bind address is purely a server-side concern; remote callers build their own URL pointing at whichever address the server is reachable on.

## Motivation

Running opensessions on a host that also hosts several Incus containers. Each container should be able to push Claude Code hook state to the central sidebar via `curl` against the host's bridge IP without SSH tunneling. Today the server is pinned to `127.0.0.1` and the README notes this as a caveat.

## Changes

- `packages/runtime/src/shared.ts` — `SERVER_HOST` reads `process.env.OPENSESSIONS_HOST ?? "127.0.0.1"`; `SERVER_PORT` reads `OPENSESSIONS_PORT` with a default. Added `LOCAL_CLIENT_HOST` constant.
- `packages/runtime/src/server/index.ts` — imports `LOCAL_CLIENT_HOST`; `setupHooks` is called with `LOCAL_CLIENT_HOST` instead of `SERVER_HOST` so tmux hooks always curl loopback regardless of where the server binds.

Existing `console.log` at startup already prints the actual bind address, which helps operators confirm the override took effect.

## Test plan

- [x] Default behavior unchanged: no env var set → server binds to `127.0.0.1:7391`, tmux hooks curl `127.0.0.1:7391`.
- [x] `OPENSESSIONS_HOST=0.0.0.0` → server accepts POSTs from remote hosts, tmux hooks still curl `127.0.0.1:7391`.
- [x] `OPENSESSIONS_PORT=8000` → server listens on alternate port, hooks updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)