### PR TITLE
feat: expose per-session window list in sidebar

### DIFF
--- a/apps/tui/src/index.tsx
+++ b/apps/tui/src/index.tsx
@@ -1700,17 +1700,42 @@ function SessionCard(props: SessionCardProps) {
           {/* Row 4: window/tab list (when session has >1 window) */}
           <Show when={(props.session.windowList?.length ?? 0) > 1}>
             <For each={props.session.windowList}>
-              {(win) => (
-                <text truncate wrapMode="none"
-                  onMouseDown={() => {
-                    props.onSwitchWindow?.(win.index);
-                  }}
-                  fg={win.active ? P().green : P().overlay0}>
-                  <span style={{ fg: win.active ? P().green : P().overlay0 }}>
-                    {`  ${win.active ? "▸" : " "} ${win.index}:${win.name}`}
-                  </span>
-                </text>
-              )}
+              {(win) => {
+                const winAgentIcon = () => {
+                  const s = (win as any).agentStatus;
+                  if (!s || s === "idle") return "";
+                  if (s === "running") return SPINNERS[props.spinIdx() % SPINNERS.length]!;
+                  if (s === "tool-running") return "⚙";
+                  if (s === "done") return "✓";
+                  if (s === "error") return "✗";
+                  if (s === "waiting") return "◉";
+                  if (s === "interrupted" || s === "stale") return "⚠";
+                  return "";
+                };
+                const winAgentColor = () => {
+                  const s = (win as any).agentStatus;
+                  if (!s || s === "idle") return "";
+                  return SC()[s] ?? P().overlay0;
+                };
+                return (
+                  <box flexDirection="row">
+                    <text truncate wrapMode="none" flexGrow={1}
+                      onMouseDown={() => {
+                        props.onSwitchWindow?.(win.index);
+                      }}
+                      fg={win.active ? P().green : P().overlay0}>
+                      <span style={{ fg: win.active ? P().green : P().overlay0 }}>
+                        {`  ${win.active ? "▸" : " "} ${win.index}:${win.name}`}
+                      </span>
+                    </text>
+                    <Show when={winAgentIcon()}>
+                      <text flexShrink={0}>
+                        <span style={{ fg: winAgentColor() }}>{" "}{winAgentIcon()}</span>
+                      </text>
+                    </Show>
+                  </box>
+                );
+              }}
             </For>
           </Show>
         </box>

--- a/apps/tui/src/index.tsx
+++ b/apps/tui/src/index.tsx
@@ -313,6 +313,13 @@ function App() {
     send({ type: "switch-session", name });
   }
 
+  function switchToWindow(sessionName: string, windowIndex: number) {
+    setCurrentSession(sessionName);
+    setFocusedSession(sessionName);
+    setPanelFocus("sessions");
+    send({ type: "switch-window", sessionName, windowIndex });
+  }
+
   function reIdentify() {
     const sessionName = getLocalSessionName();
     if (!sessionName) return;
@@ -880,6 +887,9 @@ function App() {
                 setFocusedSession(session.name);
                 send({ type: "focus-session", name: session.name });
                 switchToSession(session.name);
+              }}
+              onSwitchWindow={(windowIndex) => {
+                switchToWindow(session.name, windowIndex);
               }}
             />
           )}
@@ -1514,6 +1524,7 @@ interface SessionCardProps {
   theme: Accessor<Theme>;
   statusColors: Accessor<Theme["status"]>;
   onSelect: () => void;
+  onSwitchWindow?: (windowIndex: number) => void;
 }
 
 function SessionCard(props: SessionCardProps) {
@@ -1684,6 +1695,23 @@ function SessionCard(props: SessionCardProps) {
             <text truncate>
               <span style={{ fg: toneColor(metaTone(), P()), attributes: DIM }}>{metaSummary()}</span>
             </text>
+          </Show>
+
+          {/* Row 4: window/tab list (when session has >1 window) */}
+          <Show when={(props.session.windowList?.length ?? 0) > 1}>
+            <For each={props.session.windowList}>
+              {(win) => (
+                <text truncate wrapMode="none"
+                  onMouseDown={() => {
+                    props.onSwitchWindow?.(win.index);
+                  }}
+                  fg={win.active ? P().green : P().overlay0}>
+                  <span style={{ fg: win.active ? P().green : P().overlay0 }}>
+                    {`  ${win.active ? "▸" : " "} ${win.index}:${win.name}`}
+                  </span>
+                </text>
+              )}
+            </For>
           </Show>
         </box>
       </box>

--- a/apps/tui/src/index.tsx
+++ b/apps/tui/src/index.tsx
@@ -1703,7 +1703,8 @@ function SessionCard(props: SessionCardProps) {
               {(win) => {
                 const winAgentIcon = () => {
                   const s = (win as any).agentStatus;
-                  if (!s || s === "idle") return "";
+                  if (!s) return "";
+                  if (s === "idle") return "○";
                   if (s === "running") return SPINNERS[props.spinIdx() % SPINNERS.length]!;
                   if (s === "tool-running") return "⚙";
                   if (s === "done") return "✓";
@@ -1714,7 +1715,8 @@ function SessionCard(props: SessionCardProps) {
                 };
                 const winAgentColor = () => {
                   const s = (win as any).agentStatus;
-                  if (!s || s === "idle") return "";
+                  if (!s) return "";
+                  if (s === "idle") return P().surface2;
                   return SC()[s] ?? P().overlay0;
                 };
                 return (

--- a/packages/mux/contract/src/index.ts
+++ b/packages/mux/contract/src/index.ts
@@ -1,6 +1,7 @@
 // ─── Types ───────────────────────────────────────────────────────────────────
 export type {
   MuxSpecificationVersion,
+  MuxWindowInfo,
   MuxSessionInfo,
   ActiveWindow,
   SidebarPane,

--- a/packages/mux/contract/src/types.ts
+++ b/packages/mux/contract/src/types.ts
@@ -5,11 +5,20 @@ export type MuxSpecificationVersion = "v1";
 
 // ─── Core data types ─────────────────────────────────────────────────────────
 
+export interface MuxWindowInfo {
+  readonly id: string;
+  readonly index: number;
+  readonly name: string;
+  readonly active: boolean;
+  readonly paneCount: number;
+}
+
 export interface MuxSessionInfo {
   readonly name: string;
   readonly createdAt: number;
   readonly dir: string;
   readonly windows: number;
+  readonly windowList?: readonly MuxWindowInfo[];
 }
 
 export interface ActiveWindow {

--- a/packages/mux/providers/tmux/src/provider.ts
+++ b/packages/mux/providers/tmux/src/provider.ts
@@ -48,11 +48,26 @@ export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapabl
     const sessions = tmux.listSessions()
       .filter((s) => s.name !== STASH_SESSION);
     const activeDirs = tmux.getActiveSessionDirs();
+    const allWindows = tmux.listWindows();
+    const windowsBySession = new Map<string, typeof allWindows>();
+    for (const w of allWindows) {
+      if (w.sessionName === STASH_SESSION) continue;
+      let list = windowsBySession.get(w.sessionName);
+      if (!list) { list = []; windowsBySession.set(w.sessionName, list); }
+      list.push(w);
+    }
     return sessions.map((s) => ({
       name: s.name,
       createdAt: s.createdAt,
       dir: activeDirs.get(s.name) ?? s.dir,
       windows: s.windowCount,
+      windowList: (windowsBySession.get(s.name) ?? []).map((w) => ({
+        id: w.id,
+        index: w.index,
+        name: w.name,
+        active: w.active,
+        paneCount: w.paneCount,
+      })),
     }));
   }
 

--- a/packages/runtime/src/contracts/index.ts
+++ b/packages/runtime/src/contracts/index.ts
@@ -1,3 +1,3 @@
 export type { AgentStatus, AgentEvent } from "./agent";
 export { TERMINAL_STATUSES } from "./agent";
-export type { MuxProvider, MuxSessionInfo } from "./mux";
+export type { MuxProvider, MuxWindowInfo, MuxSessionInfo } from "./mux";

--- a/packages/runtime/src/contracts/mux.ts
+++ b/packages/runtime/src/contracts/mux.ts
@@ -1,5 +1,6 @@
 export type {
   MuxSpecificationVersion,
+  MuxWindowInfo,
   MuxSessionInfo,
   ActiveWindow,
   SidebarPane,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -49,6 +49,7 @@ export {
 } from "./shared";
 export type {
   SessionData,
+  WindowData,
   ServerState,
   FocusUpdate,
   ResizeNotify,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   MuxProvider,
   MuxProviderV1,
+  MuxWindowInfo,
   MuxSessionInfo,
   ActiveWindow,
   SidebarPane,

--- a/packages/runtime/src/server/index.ts
+++ b/packages/runtime/src/server/index.ts
@@ -525,6 +525,17 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
       }
     }
 
+    // Build paneId -> windowId map for agent-to-window association
+    const paneToWindow = new Map<string, string>();
+    try {
+      const raw = shell(["tmux", "list-panes", "-a", "-F", "#{pane_id}|#{window_id}"]);
+      for (const line of raw.split("\n")) {
+        if (!line) continue;
+        const sep = line.indexOf("|");
+        if (sep > 0) paneToWindow.set(line.slice(0, sep), line.slice(sep + 1));
+      }
+    } catch {}
+
     const sessions: SessionData[] = orderedMuxSessions.map(({ name, createdAt, windows, windowList, dir, provider }) => {
       sessionProviders.set(name, provider);
       const git = getGitInfo(dir);
@@ -554,7 +565,15 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
         ports: getSessionPorts(name),
         localLinks: buildLocalLinks(getSessionPorts(name), portlessState),
         windows,
-        windowList: (windowList ?? []) as import("../shared").SessionData["windowList"],
+        windowList: (windowList ?? []).map((w) => {
+          const agents = tracker.getAgents(name);
+          const windowAgent = agents.find((a) => a.paneId && paneToWindow.get(a.paneId) === w.id);
+          return {
+            ...w,
+            agentStatus: windowAgent?.status,
+            agentName: windowAgent?.agent,
+          };
+        }),
         uptime,
         agentState: tracker.getState(name),
         agents: tracker.getAgents(name),

--- a/packages/runtime/src/server/index.ts
+++ b/packages/runtime/src/server/index.ts
@@ -525,7 +525,7 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
       }
     }
 
-    const sessions: SessionData[] = orderedMuxSessions.map(({ name, createdAt, windows, dir, provider }) => {
+    const sessions: SessionData[] = orderedMuxSessions.map(({ name, createdAt, windows, windowList, dir, provider }) => {
       sessionProviders.set(name, provider);
       const git = getGitInfo(dir);
       const providerPaneCounts = paneCountMaps.get(provider);
@@ -554,6 +554,7 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
         ports: getSessionPorts(name),
         localLinks: buildLocalLinks(getSessionPorts(name), portlessState),
         windows,
+        windowList: (windowList ?? []) as import("../shared").SessionData["windowList"],
         uptime,
         agentState: tracker.getState(name),
         agents: tracker.getAgents(name),
@@ -1453,6 +1454,24 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
             }, 1500);
           }
         }
+        break;
+      }
+      case "switch-window": {
+        const clientSess = clientSessionNames.get(ws);
+        const tty = (clientSess ? clientTtyBySession.get(clientSess) : undefined)
+          ?? cmd.clientTty ?? clientTtys.get(ws);
+        const p = sessionProviders.get(cmd.sessionName) ?? mux;
+        p.switchSession(cmd.sessionName, tty);
+        // Select the target window by index
+        try {
+          Bun.spawnSync(["tmux", "select-window", "-t", `${cmd.sessionName}:${cmd.windowIndex}`], {
+            stdout: "pipe", stderr: "pipe",
+          });
+        } catch {}
+        focusedSession = cmd.sessionName;
+        cachedCurrentSession = cmd.sessionName;
+        cachedCurrentSessionTs = Date.now();
+        broadcastFocusOnly();
         break;
       }
       case "switch-index": {

--- a/packages/runtime/src/server/index.ts
+++ b/packages/runtime/src/server/index.ts
@@ -525,14 +525,40 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
       }
     }
 
-    // Build paneId -> windowId map for agent-to-window association
-    const paneToWindow = new Map<string, string>();
+    // Build windowId -> agent mapping by scanning pane process trees directly
+    const windowAgentMap = new Map<string, { agent: string; status: import("../contracts/agent").AgentStatus }>();
     try {
-      const raw = shell(["tmux", "list-panes", "-a", "-F", "#{pane_id}|#{window_id}"]);
+      const raw = shell(["tmux", "list-panes", "-a", "-F", "#{session_name}|#{pane_id}|#{pane_pid}|#{window_id}|#{pane_title}"]);
+      const sidebarPaneIds = new Set<string>();
+      for (const { panes: sbPanes } of listSidebarPanesByProvider()) {
+        for (const sb of sbPanes) sidebarPaneIds.add(sb.paneId);
+      }
+      const tree = buildProcessTree();
       for (const line of raw.split("\n")) {
         if (!line) continue;
-        const sep = line.indexOf("|");
-        if (sep > 0) paneToWindow.set(line.slice(0, sep), line.slice(sep + 1));
+        const i1 = line.indexOf("|");
+        const i2 = line.indexOf("|", i1 + 1);
+        const i3 = line.indexOf("|", i2 + 1);
+        const i4 = line.indexOf("|", i3 + 1);
+        const paneSession = line.slice(0, i1);
+        const paneId = line.slice(i1 + 1, i2);
+        const panePid = parseInt(line.slice(i2 + 1, i3), 10);
+        const windowId = line.slice(i3 + 1, i4);
+        const paneTitle = line.slice(i4 + 1);
+        if (sidebarPaneIds.has(paneId)) continue;
+        if (paneTitle === "opensessions-sidebar") continue;
+        for (const [agentName, patterns] of Object.entries(AGENT_TITLE_PATTERNS)) {
+          if (!matchProcessTreeFast(panePid, patterns, tree)) continue;
+          // Get the best status from the tracker for this agent in this session
+          const agents = tracker.getAgents(paneSession);
+          const agentEvent = agents.find((a) => a.agent === agentName);
+          const status = agentEvent?.status ?? "idle";
+          const existing = windowAgentMap.get(windowId);
+          // Keep the most active status if multiple agents in same window
+          if (!existing || STATUS_PRIORITY[status] > STATUS_PRIORITY[existing.status]) {
+            windowAgentMap.set(windowId, { agent: agentName, status });
+          }
+        }
       }
     } catch {}
 
@@ -566,12 +592,11 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
         localLinks: buildLocalLinks(getSessionPorts(name), portlessState),
         windows,
         windowList: (windowList ?? []).map((w) => {
-          const agents = tracker.getAgents(name);
-          const windowAgent = agents.find((a) => a.paneId && paneToWindow.get(a.paneId) === w.id);
+          const winAgent = windowAgentMap.get(w.id);
           return {
             ...w,
-            agentStatus: windowAgent?.status,
-            agentName: windowAgent?.agent,
+            agentStatus: winAgent?.status,
+            agentName: winAgent?.agent,
           };
         }),
         uptime,
@@ -1073,6 +1098,11 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
     "claude-code": ["claude"],
     codex: ["codex"],
     opencode: ["opencode"],
+  };
+
+  const STATUS_PRIORITY: Record<string, number> = {
+    "tool-running": 7, running: 6, error: 5, stale: 4,
+    interrupted: 3, waiting: 2, done: 1, idle: 0,
   };
 
   const PANE_HIGHLIGHT_BORDER = "fg=#fab387,bold";

--- a/packages/runtime/src/shared.ts
+++ b/packages/runtime/src/shared.ts
@@ -15,6 +15,11 @@ export interface LocalLink {
   label: string;
 }
 
+export interface WindowData extends MuxWindowInfo {
+  agentStatus?: AgentStatus;
+  agentName?: string;
+}
+
 export interface SessionData {
   name: string;
   createdAt: number;
@@ -27,7 +32,7 @@ export interface SessionData {
   ports: number[];
   localLinks: LocalLink[];
   windows: number;
-  windowList: MuxWindowInfo[];
+  windowList: WindowData[];
   uptime: string;
   agentState: AgentEvent | null;
   agents: AgentEvent[];

--- a/packages/runtime/src/shared.ts
+++ b/packages/runtime/src/shared.ts
@@ -1,5 +1,5 @@
 import type { AgentStatus, AgentEvent } from "./contracts/agent";
-import type { MuxSessionInfo } from "./contracts/mux";
+import type { MuxSessionInfo, MuxWindowInfo } from "./contracts/mux";
 import type { SessionFilterMode } from "./config";
 
 export const SERVER_PORT = 7391;
@@ -27,6 +27,7 @@ export interface SessionData {
   ports: number[];
   localLinks: LocalLink[];
   windows: number;
+  windowList: MuxWindowInfo[];
   uptime: string;
   agentState: AgentEvent | null;
   agents: AgentEvent[];
@@ -107,6 +108,7 @@ export interface SessionMetadata {
 
 export type ClientCommand =
   | { type: "switch-session"; name: string; clientTty?: string }
+  | { type: "switch-window"; sessionName: string; windowIndex: number; clientTty?: string }
   | { type: "switch-index"; index: number }
   | { type: "new-session" }
   | { type: "hide-session"; name: string }


### PR DESCRIPTION
## Summary

- Adds per-session window/tab enumeration to the sidebar, so sessions with multiple tmux windows show each window as a clickable row
- Introduces `MuxWindowInfo` type and optional `windowList` field on `MuxSessionInfo`
- Adds `switch-window` client command to switch directly to a specific window within a session
- Windows are only displayed when a session has more than one tab

## Changes

**Contract** (`packages/mux/contract`):
- New `MuxWindowInfo` interface (`id`, `index`, `name`, `active`, `paneCount`)
- `MuxSessionInfo.windowList` optional field

**TmuxProvider** (`packages/mux/providers/tmux`):
- Batch-fetches all windows via `listWindows()` and groups by session name
- Populates `windowList` in `listSessions()`

**Runtime** (`packages/runtime`):
- `SessionData.windowList` field piped through `computeState()`
- `switch-window` command handler in the server

**TUI** (`apps/tui`):
- `SessionCard` renders window rows (with active indicator) when `windowList.length > 1`
- Clicking a window row sends `switch-window` command

## Test plan

- [x] `bun test` - 349 tests pass
- [x] `bun run build` - builds successfully
- [ ] Manual: open sidebar with multi-window session, verify windows shown
- [ ] Manual: click a window row, verify it switches to that window