### PR TITLE
fix(runtime): canonicalize pi pane ownership and sidebar focus

### DIFF
--- a/integrations/pi-extension/README.md
+++ b/integrations/pi-extension/README.md
@@ -1,0 +1,31 @@
+# opensessions Pi runtime extension
+
+Pi extension that registers the live `pi` process with opensessions so tmux pane scans can map Pi session IDs to exact panes.
+
+## Usage
+
+Run Pi with the extension:
+
+```bash
+pi --extension /path/to/opensessions/integrations/pi-extension/opensessions-runtime.ts
+```
+
+Or copy/symlink the file into one of Pi's extension locations:
+
+- `~/.pi/agent/extensions/`
+- `.pi/extensions/`
+
+## What it does
+
+The extension POSTs the current Pi runtime identity to opensessions on localhost:
+
+- `POST /api/runtime/pi/upsert` on `session_start`
+- heartbeat every 5 seconds while Pi is alive
+- `POST /api/runtime/pi/delete` on `session_shutdown`
+
+By default it talks to `http://127.0.0.1:7391`.
+Override with:
+
+```bash
+export OPENSESSIONS_URL=http://127.0.0.1:7391
+```

--- a/integrations/pi-extension/opensessions-runtime.ts
+++ b/integrations/pi-extension/opensessions-runtime.ts
@@ -1,0 +1,92 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+interface PiRuntimePayload {
+  pid: number;
+  ppid: number;
+  sessionId: string;
+  sessionFile?: string;
+  cwd: string;
+  sessionName?: string;
+  ts: number;
+}
+
+const DEFAULT_SERVER_URL = "http://127.0.0.1:7391";
+const HEARTBEAT_MS = 5_000;
+
+function getServerUrl(): string {
+  return (process.env.OPENSESSIONS_URL ?? DEFAULT_SERVER_URL).replace(/\/+$/, "");
+}
+
+export default function opensessionsRuntime(pi: ExtensionAPI) {
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
+  let current: Omit<PiRuntimePayload, "ts" | "sessionName"> | null = null;
+
+  function buildPayload(ctx: ExtensionContext): PiRuntimePayload {
+    return {
+      pid: process.pid,
+      ppid: process.ppid,
+      sessionId: ctx.sessionManager.getSessionId(),
+      sessionFile: ctx.sessionManager.getSessionFile(),
+      cwd: ctx.sessionManager.getCwd(),
+      sessionName: pi.getSessionName(),
+      ts: Date.now(),
+    };
+  }
+
+  async function post(path: string, body: unknown): Promise<void> {
+    try {
+      await fetch(`${getServerUrl()}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // opensessions may not be running yet; retry on next heartbeat
+    }
+  }
+
+  function clearHeartbeat(): void {
+    if (!heartbeat) return;
+    clearInterval(heartbeat);
+    heartbeat = null;
+  }
+
+  function startHeartbeat(ctx: ExtensionContext): void {
+    clearHeartbeat();
+    heartbeat = setInterval(() => {
+      if (!current) {
+        current = {
+          pid: process.pid,
+          ppid: process.ppid,
+          sessionId: ctx.sessionManager.getSessionId(),
+          sessionFile: ctx.sessionManager.getSessionFile(),
+          cwd: ctx.sessionManager.getCwd(),
+        };
+      }
+      void post("/api/runtime/pi/upsert", {
+        ...current,
+        sessionName: pi.getSessionName(),
+        ts: Date.now(),
+      } satisfies PiRuntimePayload);
+    }, HEARTBEAT_MS);
+  }
+
+  pi.on("session_start", async (_event, ctx) => {
+    const payload = buildPayload(ctx);
+    current = {
+      pid: payload.pid,
+      ppid: payload.ppid,
+      sessionId: payload.sessionId,
+      sessionFile: payload.sessionFile,
+      cwd: payload.cwd,
+    };
+    void post("/api/runtime/pi/upsert", payload);
+    startHeartbeat(ctx);
+  });
+
+  pi.on("session_shutdown", async () => {
+    clearHeartbeat();
+    current = null;
+    void post("/api/runtime/pi/delete", { pid: process.pid });
+  });
+}

--- a/packages/mux/providers/tmux/src/provider.ts
+++ b/packages/mux/providers/tmux/src/provider.ts
@@ -276,17 +276,28 @@ export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapabl
 
   killOrphanedSidebarPanes(): void {
     const allPanes = tmux.listPanes();
-    // Count panes per window
+    // Count panes per window and collect sidebar panes by window.
     const windowPaneCounts = new Map<string, number>();
+    const sidebarsByWindow = new Map<string, typeof allPanes>();
     for (const p of allPanes) {
       if (p.sessionName === STASH_SESSION) continue;
       windowPaneCounts.set(p.windowId, (windowPaneCounts.get(p.windowId) ?? 0) + 1);
+      if (p.title !== SIDEBAR_PANE_TITLE) continue;
+      const panes = sidebarsByWindow.get(p.windowId) ?? [];
+      panes.push(p);
+      sidebarsByWindow.set(p.windowId, panes);
     }
-    // Find sidebar panes that are the only pane in their window
-    for (const p of allPanes) {
-      if (p.title !== SIDEBAR_PANE_TITLE || p.sessionName === STASH_SESSION) continue;
-      if (windowPaneCounts.get(p.windowId) === 1) {
-        tmux.killPane(p.id);
+
+    for (const [windowId, sidebars] of sidebarsByWindow) {
+      if (windowPaneCounts.get(windowId) === 1) {
+        for (const pane of sidebars) tmux.killPane(pane.id);
+        continue;
+      }
+      if (sidebars.length <= 1) continue;
+      // Defensive cleanup: keep a single sidebar per window, kill extras.
+      for (const pane of sidebars.slice(1)) {
+        plog("killOrphanedSidebarPanes: killing duplicate sidebar", { paneId: pane.id, windowId });
+        tmux.killPane(pane.id);
       }
     }
   }

--- a/packages/runtime/src/agents/tracker.ts
+++ b/packages/runtime/src/agents/tracker.ts
@@ -3,6 +3,7 @@ import { TERMINAL_STATUSES } from "../contracts/agent";
 
 const MAX_EVENT_TIMESTAMPS = 30;
 const TERMINAL_PRUNE_MS = 5 * 60 * 1000;
+const SYNTHETIC_PANE_MARKER = ":pane:";
 
 const STATUS_PRIORITY: Record<string, number> = {
   "tool-running": 7,
@@ -17,6 +18,16 @@ const STATUS_PRIORITY: Record<string, number> = {
 
 export function instanceKey(agent: string, threadId?: string): string {
   return threadId ? `${agent}:${threadId}` : agent;
+}
+
+function syntheticPaneKey(agent: string, paneId: string, threadId?: string): string {
+  return threadId
+    ? `${agent}:${threadId}${SYNTHETIC_PANE_MARKER}${paneId}`
+    : `${agent}${SYNTHETIC_PANE_MARKER}${paneId}`;
+}
+
+function isSyntheticPaneKey(key: string): boolean {
+  return key.includes(SYNTHETIC_PANE_MARKER);
 }
 
 export class AgentTracker {
@@ -48,18 +59,33 @@ export class AgentTracker {
     }
     sessionInstances.set(key, event);
 
-    // Clean up any synthetic pane-keyed entries for this agent
-    // (pane scanner may have created a minimal synthetic before the watcher seeded)
+    // Clean up a matching synthetic pane-keyed entry for this agent.
+    // Prefer exact thread matches. Fall back to a single generic synthetic
+    // only when there is no ambiguity.
+    const exactSyntheticMatches: Array<{ key: string; event: AgentEvent }> = [];
+    const genericSyntheticMatches: Array<{ key: string; event: AgentEvent }> = [];
     for (const [k, ev] of sessionInstances) {
-      if (k !== key && ev.agent === event.agent && k.includes(":pane:")) {
-        // Transfer pane info from the synthetic to the watcher entry
-        if (ev.paneId && !event.paneId) {
-          event.paneId = ev.paneId;
-          event.liveness = ev.liveness;
-        }
-        sessionInstances.delete(k);
-        this.unseenInstances.delete(this.unseenKey(event.session, k));
+      if (k === key || ev.agent !== event.agent || !isSyntheticPaneKey(k)) continue;
+      if (ev.threadId && event.threadId && ev.threadId === event.threadId) {
+        exactSyntheticMatches.push({ key: k, event: ev });
+      } else if (!ev.threadId) {
+        genericSyntheticMatches.push({ key: k, event: ev });
       }
+    }
+
+    const matchToMerge = exactSyntheticMatches.length === 1
+      ? exactSyntheticMatches[0]
+      : exactSyntheticMatches.length === 0 && genericSyntheticMatches.length === 1
+        ? genericSyntheticMatches[0]
+        : undefined;
+
+    if (matchToMerge) {
+      if (matchToMerge.event.paneId && !event.paneId) {
+        event.paneId = matchToMerge.event.paneId;
+        event.liveness = matchToMerge.event.liveness;
+      }
+      sessionInstances.delete(matchToMerge.key);
+      this.unseenInstances.delete(this.unseenKey(event.session, matchToMerge.key));
     }
 
     // Track event timestamps
@@ -151,6 +177,27 @@ export class AgentTracker {
     return true;
   }
 
+  /** Ensure a specific watcher instance only exists in one session.
+   *  Useful when cwd-based watcher resolution and live pane ownership disagree.
+   *  Returns true if any duplicate instances were removed from other sessions. */
+  dedupeInstanceToSession(session: string, agent: string, threadId?: string): boolean {
+    if (!threadId) return false;
+    const key = instanceKey(agent, threadId);
+    let changed = false;
+
+    for (const [otherSession, sessionInstances] of this.instances) {
+      if (otherSession === session) continue;
+      if (!sessionInstances.delete(key)) continue;
+      this.unseenInstances.delete(this.unseenKey(otherSession, key));
+      if (sessionInstances.size === 0) {
+        this.instances.delete(otherSession);
+      }
+      changed = true;
+    }
+
+    return changed;
+  }
+
   pruneStuck(timeoutMs: number): void {
     const now = Date.now();
     for (const [session, sessionInstances] of this.instances) {
@@ -229,12 +276,13 @@ export class AgentTracker {
   }
 
   /** Fold pane scanner results into the tracker.
-   *  The scanner only reports {agent, paneId} — no threadId, status, or threadName.
-   *  Watchers are the single source of truth for those fields.
+   *  The scanner reports {agent, paneId} and may include threadId when it can
+   *  resolve a live process to a specific watcher instance.
    *
    *  1. Entries with liveness "alive" whose paneId is missing from the scan → "exited"
-   *  2. Each pane agent: find existing entry for this agent → stamp paneId + liveness.
-   *     If none exists, create a minimal synthetic (status: "idle", liveness: "alive").
+   *  2. Exact threadId matches enrich the corresponding watcher entry.
+   *  3. If no exact match exists, unambiguous single-instance matches fall back by agent.
+   *  4. Otherwise create or update a synthetic pane-backed idle entry.
    *  Returns true if anything changed (caller uses this for broadcast decisions). */
   applyPanePresence(session: string, paneAgents: PanePresenceInput[]): boolean {
     let changed = false;
@@ -262,28 +310,67 @@ export class AgentTracker {
         this.instances.set(session, sessionInstances);
       }
 
-      // Find an existing entry for this agent (prefer watcher-sourced over synthetic)
-      let bestEvent: AgentEvent | undefined;
-      for (const [k, ev] of sessionInstances) {
-        if (ev.agent !== pa.agent) continue;
-        if (!bestEvent || !k.includes(":pane:")) {
-          bestEvent = ev;
-          // If this is a watcher-sourced entry (not pane-keyed), prefer it and stop
-          if (!k.includes(":pane:")) break;
-        }
-      }
-
-      if (bestEvent) {
-        const wasDifferent = bestEvent.paneId !== pa.paneId || bestEvent.liveness !== "alive";
-        bestEvent.paneId = pa.paneId;
-        bestEvent.liveness = "alive";
+      const stampAlive = (target: AgentEvent) => {
+        const wasDifferent = target.paneId !== pa.paneId || target.liveness !== "alive";
+        target.paneId = pa.paneId;
+        target.liveness = "alive";
         if (wasDifferent) changed = true;
+      };
+
+      if (pa.threadId) {
+        const exactKey = instanceKey(pa.agent, pa.threadId);
+        const exactEvent = sessionInstances.get(exactKey);
+        if (exactEvent) {
+          stampAlive(exactEvent);
+
+          // Drop any synthetic for the same pane now that we have an exact watcher entry.
+          const genericSyntheticKey = syntheticPaneKey(pa.agent, pa.paneId);
+          const exactSyntheticKey = syntheticPaneKey(pa.agent, pa.paneId, pa.threadId);
+          if (sessionInstances.delete(genericSyntheticKey)) {
+            this.unseenInstances.delete(this.unseenKey(session, genericSyntheticKey));
+          }
+          if (sessionInstances.delete(exactSyntheticKey)) {
+            this.unseenInstances.delete(this.unseenKey(session, exactSyntheticKey));
+          }
+          continue;
+        }
+
+        const exactSyntheticKey = syntheticPaneKey(pa.agent, pa.paneId, pa.threadId);
+        const genericSyntheticKey = syntheticPaneKey(pa.agent, pa.paneId);
+        const existing = sessionInstances.get(exactSyntheticKey);
+        if (existing) {
+          stampAlive(existing);
+          continue;
+        }
+
+        if (sessionInstances.delete(genericSyntheticKey)) {
+          this.unseenInstances.delete(this.unseenKey(session, genericSyntheticKey));
+        }
+
+        sessionInstances.set(exactSyntheticKey, {
+          agent: pa.agent,
+          session,
+          status: "idle",
+          ts: Date.now(),
+          threadId: pa.threadId,
+          paneId: pa.paneId,
+          liveness: "alive",
+        });
+        changed = true;
         continue;
       }
 
-      // No existing entry — create minimal synthetic
-      const syntheticKey = `${pa.agent}:pane:${pa.paneId}`;
-      if (!sessionInstances.has(syntheticKey)) {
+      const watcherEntries = [...sessionInstances.entries()]
+        .filter(([k, ev]) => ev.agent === pa.agent && !isSyntheticPaneKey(k));
+
+      if (watcherEntries.length === 1) {
+        stampAlive(watcherEntries[0]![1]);
+        continue;
+      }
+
+      const syntheticKey = syntheticPaneKey(pa.agent, pa.paneId);
+      const existing = sessionInstances.get(syntheticKey);
+      if (!existing) {
         sessionInstances.set(syntheticKey, {
           agent: pa.agent,
           session,
@@ -294,11 +381,7 @@ export class AgentTracker {
         });
         changed = true;
       } else {
-        const existing = sessionInstances.get(syntheticKey)!;
-        const wasDifferent = existing.paneId !== pa.paneId || existing.liveness !== "alive";
-        existing.paneId = pa.paneId;
-        existing.liveness = "alive";
-        if (wasDifferent) changed = true;
+        stampAlive(existing);
       }
     }
 

--- a/packages/runtime/src/agents/watchers/pi.ts
+++ b/packages/runtime/src/agents/watchers/pi.ts
@@ -12,7 +12,7 @@
 import { watch, type FSWatcher } from "fs";
 import { readdir, stat } from "fs/promises";
 import { homedir } from "os";
-import { basename, dirname, join } from "path";
+import { basename, join } from "path";
 import type { AgentStatus } from "../../contracts/agent";
 import type {
   AgentWatcher,
@@ -201,6 +201,15 @@ export class PiAgentWatcher implements AgentWatcher {
     this.ctx = null;
   }
 
+  private resolveEventSession(threadId: string, snapshot: SessionSnapshot): string | null {
+    if (!this.ctx) return null;
+    const byProjectDir = snapshot.projectDir
+      ? this.ctx.resolveSession(snapshot.projectDir)
+      : null;
+    if (byProjectDir) return byProjectDir;
+    return this.ctx.resolveThreadOwner?.("pi", threadId)?.session ?? null;
+  }
+
   private async processFile(filePath: string): Promise<void> {
     if (!this.ctx) return;
 
@@ -211,7 +220,6 @@ export class PiAgentWatcher implements AgentWatcher {
       return;
     }
 
-    const encodedDir = basename(dirname(filePath));
     const threadId = parseThreadId(filePath);
     const prev = this.sessions.get(threadId);
 
@@ -244,10 +252,6 @@ export class PiAgentWatcher implements AgentWatcher {
       });
     }
 
-    if (!nextSnapshot.projectDir) {
-      nextSnapshot.projectDir = encodedDir;
-    }
-
     this.sessions.set(threadId, nextSnapshot);
 
     if (!this.seeded) return;
@@ -255,9 +259,7 @@ export class PiAgentWatcher implements AgentWatcher {
     const prevStatus = prev?.status;
     if (nextSnapshot.status === prevStatus) return;
 
-    const session = nextSnapshot.projectDir
-      ? this.ctx.resolveSession(nextSnapshot.projectDir)
-      : null;
+    const session = this.resolveEventSession(threadId, nextSnapshot);
     if (!session) return;
     if (!prev && nextSnapshot.status === "idle") return;
 
@@ -295,9 +297,9 @@ export class PiAgentWatcher implements AgentWatcher {
         this.seeded = true;
 
         for (const [threadId, snapshot] of this.sessions) {
-          if (snapshot.status === "idle" || !snapshot.projectDir) continue;
+          if (snapshot.status === "idle") continue;
 
-          const session = this.ctx.resolveSession(snapshot.projectDir);
+          const session = this.resolveEventSession(threadId, snapshot);
           if (!session) continue;
 
           this.ctx.emit({

--- a/packages/runtime/src/contracts/agent-watcher.ts
+++ b/packages/runtime/src/contracts/agent-watcher.ts
@@ -5,9 +5,16 @@ import type { AgentEvent } from "./agent";
  * Lets watchers resolve project directories to mux session names
  * and emit events without knowing about server internals.
  */
+export interface AgentThreadOwner {
+  session: string;
+  paneId?: string;
+}
+
 export interface AgentWatcherContext {
   /** Resolve a project directory path to a mux session name, or null if unmatched */
   resolveSession(projectDir: string): string | null;
+  /** Resolve the live owner for a specific agent thread when pane-backed identity is available. */
+  resolveThreadOwner?(agent: string, threadId?: string): AgentThreadOwner | null;
   /** Emit an agent event (applied to tracker + broadcast automatically) */
   emit(event: AgentEvent): void;
 }

--- a/packages/runtime/src/contracts/agent.ts
+++ b/packages/runtime/src/contracts/agent.ts
@@ -22,9 +22,11 @@ export interface AgentEvent {
 export const TERMINAL_STATUSES = new Set<AgentStatus>(["done", "error", "interrupted", "stale"]);
 
 /** Input from the pane scanner to applyPanePresence().
- *  The scanner only answers "is there a live agent process in this pane?"
- *  Status, threadId, and threadName come exclusively from watchers. */
+ *  The scanner reports "is there a live agent process in this pane?" and may
+ *  optionally resolve that process to a watcher threadId using agent-specific
+ *  runtime metadata. Status and threadName still come exclusively from watchers. */
 export interface PanePresenceInput {
   agent: string;
   paneId: string;
+  threadId?: string;
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from "./contracts/mux";
 export type { AgentStatus, AgentLiveness, AgentEvent, PanePresenceInput } from "./contracts/agent";
 export { TERMINAL_STATUSES } from "./contracts/agent";
-export type { AgentWatcher, AgentWatcherContext } from "./contracts/agent-watcher";
+export type { AgentWatcher, AgentWatcherContext, AgentThreadOwner } from "./contracts/agent-watcher";
 export { AgentTracker } from "./agents/tracker";
 export { AmpAgentWatcher } from "./agents/watchers/amp";
 export { ClaudeCodeAgentWatcher } from "./agents/watchers/claude-code";

--- a/packages/runtime/src/server/agent-ownership.ts
+++ b/packages/runtime/src/server/agent-ownership.ts
@@ -1,0 +1,27 @@
+import type { AgentEvent } from "../contracts/agent";
+import type { AgentThreadOwner } from "../contracts/agent-watcher";
+
+export type ResolveThreadOwner = (agent: string, threadId?: string) => AgentThreadOwner | null;
+
+export function canonicalizeAgentEvent(
+  event: AgentEvent,
+  resolveThreadOwner?: ResolveThreadOwner,
+): AgentEvent {
+  if (!event.threadId || !resolveThreadOwner) return event;
+
+  const owner = resolveThreadOwner(event.agent, event.threadId);
+  if (!owner) return event;
+
+  if (owner.session === event.session) {
+    if (owner.paneId && !event.paneId) {
+      return { ...event, paneId: owner.paneId };
+    }
+    return event;
+  }
+
+  return {
+    ...event,
+    session: owner.session,
+    ...(owner.paneId && !event.paneId && { paneId: owner.paneId }),
+  };
+}

--- a/packages/runtime/src/server/index.ts
+++ b/packages/runtime/src/server/index.ts
@@ -3,11 +3,14 @@ import { join } from "path";
 import { homedir } from "os";
 import type { MuxProvider } from "../contracts/mux";
 import { isFullSidebarCapable, isBatchCapable } from "../contracts/mux";
-import type { AgentEvent } from "../contracts/agent";
-import type { AgentWatcher, AgentWatcherContext } from "../contracts/agent-watcher";
+import type { AgentEvent, PanePresenceInput } from "../contracts/agent";
+import type { AgentThreadOwner, AgentWatcher, AgentWatcherContext } from "../contracts/agent-watcher";
 import { AgentTracker } from "../agents/tracker";
 import { SessionOrder } from "./session-order";
 import { SessionMetadataStore } from "./metadata-store";
+import { canonicalizeAgentEvent } from "./agent-ownership";
+import { PiLiveResolver } from "./pi-live-resolver";
+import { parsePiRuntimeInfo } from "./pi-runtime-registry";
 import { buildLocalLinks, loadPortlessState } from "./portless";
 import {
   areWidthReportsSuppressed,
@@ -340,6 +343,58 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
     return map;
   }
 
+  const piLiveResolver = new PiLiveResolver({
+    listPanes: () => {
+      const raw = shell([
+        "tmux", "list-panes", "-a",
+        "-F", "#{session_name}|#{pane_id}|#{pane_pid}",
+      ]);
+      if (!raw) return [];
+      return raw.split("\n")
+        .filter(Boolean)
+        .map((line) => {
+          const idx1 = line.indexOf("|");
+          const idx2 = line.indexOf("|", idx1 + 1);
+          return {
+            session: line.slice(0, idx1),
+            paneId: line.slice(idx1 + 1, idx2),
+            pid: parseInt(line.slice(idx2 + 1), 10),
+          };
+        })
+        .filter((pane) => !Number.isNaN(pane.pid));
+    },
+    listSidebarPaneIds: function* () {
+      for (const { panes } of listSidebarPanesByProvider()) {
+        for (const pane of panes) yield pane.paneId;
+      }
+    },
+    buildProcessTree,
+  });
+
+  function resolveThreadOwner(agent: string, threadId?: string): AgentThreadOwner | null {
+    if (agent === "pi" && threadId) {
+      const owner = piLiveResolver.resolveThreadOwner(threadId);
+      return owner ? { session: owner.session, paneId: owner.paneId } : null;
+    }
+    return null;
+  }
+
+  function canonicalizeOwnedEvent(event: AgentEvent): AgentEvent {
+    const nextEvent = canonicalizeAgentEvent(event, resolveThreadOwner);
+    if (event.session !== nextEvent.session && nextEvent.threadId) {
+      log("agent-emit", "thread owner override", {
+        agent: nextEvent.agent,
+        from: event.session,
+        to: nextEvent.session,
+        threadId: nextEvent.threadId.slice(0, 8),
+      });
+    }
+    if (nextEvent.threadId) {
+      tracker.dedupeInstanceToSession(nextEvent.session, nextEvent.agent, nextEvent.threadId);
+    }
+    return nextEvent;
+  }
+
   const watcherCtx: AgentWatcherContext = {
     resolveSession(projectDir: string): string | null {
       const map = getDirSessionMap();
@@ -361,9 +416,11 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
       }
       return null;
     },
+    resolveThreadOwner,
     emit(event: AgentEvent) {
-      log("agent-emit", event.agent, { session: event.session, status: event.status, threadId: event.threadId?.slice(0, 8) });
-      tracker.applyEvent(event, { seed: !watchersSeeded });
+      const nextEvent = canonicalizeOwnedEvent(event);
+      log("agent-emit", nextEvent.agent, { session: nextEvent.session, status: nextEvent.status, threadId: nextEvent.threadId?.slice(0, 8) });
+      tracker.applyEvent(nextEvent, { seed: !watchersSeeded });
       debouncedBroadcast();
     },
   };
@@ -1185,13 +1242,27 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
     return undefined;
   }
 
+  function getTrackedAlivePaneId(sessionName: string, agentName: string, threadId?: string): string | undefined {
+    if (!threadId) return undefined;
+    return tracker.getAgents(sessionName)
+      .find((agent) => agent.agent === agentName && agent.threadId === threadId && agent.liveness === "alive" && !!agent.paneId)
+      ?.paneId;
+  }
+
+  function resolvePiPane(threadId: string): string | undefined {
+    return piLiveResolver.resolveThreadPane(threadId, { fresh: true });
+  }
+
   /** Resolve a tmux pane ID for an agent using all available resolution strategies. */
   function resolveAgentPaneId(sessionName: string, agentName: string, threadId?: string, threadName?: string): string | undefined {
+    const trackedPaneId = getTrackedAlivePaneId(sessionName, agentName, threadId);
+    if (trackedPaneId) return trackedPaneId;
+
     const p = sessionProviders.get(sessionName) ?? mux;
     if (p.name !== "tmux") return undefined;
 
     const patterns = AGENT_TITLE_PATTERNS[agentName];
-    if (!patterns) return undefined;
+    if (!patterns && agentName !== "pi") return undefined;
 
     const raw = shell([
       "tmux", "list-panes", "-s", "-t", sessionName,
@@ -1234,12 +1305,18 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
     if (!targetPaneId && agentName === "opencode" && threadId) {
       targetPaneId = resolveOpenCodePane(nonSidebar, threadId);
     }
-    if (!targetPaneId) {
+    if (!targetPaneId && agentName === "pi" && threadId) {
+      targetPaneId = resolvePiPane(threadId);
+      if (targetPaneId && sidebarPaneIds.has(targetPaneId)) {
+        targetPaneId = undefined;
+      }
+    }
+    if (!targetPaneId && patterns) {
       targetPaneId = nonSidebar
         .find((p) => patterns.some((pat) => p.title.toLowerCase().includes(pat)))
         ?.id;
     }
-    if (!targetPaneId) {
+    if (!targetPaneId && patterns) {
       for (const pane of nonSidebar) {
         if (matchProcessTree(pane.pid, patterns)) {
           targetPaneId = pane.id;
@@ -1341,12 +1418,11 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
     return false;
   }
 
-
   /** Scan all panes across all tmux sessions and identify running agents.
-   *  Returns only {agent, paneId} — no threadId, status, or threadName.
-   *  Watchers are the single source of truth for those fields. */
-  function scanAllTmuxPaneAgents(): Map<string, import("../contracts/agent").PanePresenceInput[]> {
-    const result = new Map<string, import("../contracts/agent").PanePresenceInput[]>();
+   *  Returns pane presence, optionally enriched with threadId when an agent-specific
+   *  runtime registry can resolve a live process to a watcher thread. */
+  function scanAllTmuxPaneAgents(): Map<string, PanePresenceInput[]> {
+    const result = new Map<string, PanePresenceInput[]>();
 
     const raw = shell([
       "tmux", "list-panes", "-a",
@@ -1393,6 +1469,16 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
         }
         sessionAgents.push({ agent: agentName, paneId: pane.id });
       }
+
+    }
+
+    for (const [session, paneAgents] of piLiveResolver.scanPresenceBySession()) {
+      let sessionAgents = result.get(session);
+      if (!sessionAgents) {
+        sessionAgents = [];
+        result.set(session, sessionAgents);
+      }
+      sessionAgents.push(...paneAgents);
     }
 
     return result;
@@ -1413,6 +1499,11 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
 
     // Apply presence for sessions that have pane agents
     for (const [session, paneAgents] of nextBySession) {
+      for (const paneAgent of paneAgents) {
+        if (paneAgent.threadId) {
+          if (tracker.dedupeInstanceToSession(session, paneAgent.agent, paneAgent.threadId)) changed = true;
+        }
+      }
       if (tracker.applyPanePresence(session, paneAgents)) changed = true;
     }
 
@@ -1860,6 +1951,34 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
           }
         }
         return new Response("ok", { status: 200 });
+      }
+
+      if (req.method === "POST" && url.pathname === "/api/runtime/pi/upsert") {
+        try {
+          const parsed = parsePiRuntimeInfo(await req.json());
+          if (!parsed) {
+            return new Response("invalid pi runtime payload", { status: 400 });
+          }
+          piLiveResolver.upsert(parsed);
+          if (clientCount > 0) refreshPaneAgents();
+          return new Response(null, { status: 204 });
+        } catch {
+          return new Response("invalid json", { status: 400 });
+        }
+      }
+
+      if (req.method === "POST" && url.pathname === "/api/runtime/pi/delete") {
+        try {
+          const body = await req.json() as { pid?: number };
+          if (typeof body.pid !== "number" || !Number.isInteger(body.pid) || body.pid <= 0) {
+            return new Response("missing pid", { status: 400 });
+          }
+          piLiveResolver.delete(body.pid);
+          if (clientCount > 0) refreshPaneAgents();
+          return new Response(null, { status: 204 });
+        } catch {
+          return new Response("invalid json", { status: 400 });
+        }
       }
 
       if (req.method === "POST" && url.pathname === "/set-status") {

--- a/packages/runtime/src/server/pi-live-resolver.ts
+++ b/packages/runtime/src/server/pi-live-resolver.ts
@@ -1,0 +1,188 @@
+import type { PanePresenceInput } from "../contracts/agent";
+import { PiRuntimeRegistry, type PiRuntimeInfo } from "./pi-runtime-registry";
+
+const DEFAULT_CACHE_TTL_MS = 1_000;
+
+export interface ProcessTreeSnapshot {
+  childrenOf: Map<number, number[]>;
+  commOf: Map<number, string>;
+}
+
+export interface PiPaneEntry {
+  session: string;
+  paneId: string;
+  pid: number;
+}
+
+export interface PiThreadOwner {
+  threadId: string;
+  session: string;
+  paneId: string;
+  pid: number;
+}
+
+interface PiLiveSnapshot {
+  builtAt: number;
+  ownersByThreadId: Map<string, PiThreadOwner | null>;
+  presenceBySession: Map<string, PanePresenceInput[]>;
+}
+
+export interface PiLiveResolverDeps {
+  listPanes(): PiPaneEntry[];
+  listSidebarPaneIds(): Iterable<string>;
+  buildProcessTree(): ProcessTreeSnapshot;
+  now?(): number;
+}
+
+function isExactCommand(comm: string, name: string): boolean {
+  return comm === name || comm.endsWith(`/${name}`);
+}
+
+function collectDescendantPidsFast(
+  pid: number,
+  matcher: (comm: string) => boolean,
+  tree: ProcessTreeSnapshot,
+  depth = 0,
+  out: number[] = [],
+): number[] {
+  if (depth > 2) return out;
+  const children = tree.childrenOf.get(pid);
+  if (!children) return out;
+  for (const childPid of children) {
+    const comm = tree.commOf.get(childPid);
+    if (comm && matcher(comm)) out.push(childPid);
+    collectDescendantPidsFast(childPid, matcher, tree, depth + 1, out);
+  }
+  return out;
+}
+
+export class PiLiveResolver {
+  private snapshot: PiLiveSnapshot | null = null;
+
+  constructor(
+    private readonly deps: PiLiveResolverDeps,
+    private readonly registry = new PiRuntimeRegistry(),
+    private readonly cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  ) {}
+
+  upsert(info: PiRuntimeInfo): void {
+    this.registry.upsert(info);
+    this.invalidate();
+  }
+
+  delete(pid: number): boolean {
+    const removed = this.registry.delete(pid);
+    if (removed) this.invalidate();
+    return removed;
+  }
+
+  prune(now = this.now()): boolean {
+    const changed = this.registry.prune(now);
+    if (changed) this.invalidate();
+    return changed;
+  }
+
+  resolveThreadOwner(threadId: string, options?: { fresh?: boolean }): PiThreadOwner | null {
+    return this.getSnapshot(options).ownersByThreadId.get(threadId) ?? null;
+  }
+
+  resolveThreadSession(threadId: string, options?: { fresh?: boolean }): string | null {
+    return this.resolveThreadOwner(threadId, options)?.session ?? null;
+  }
+
+  resolveThreadPane(threadId: string, options?: { fresh?: boolean }): string | undefined {
+    return this.resolveThreadOwner(threadId, options)?.paneId;
+  }
+
+  scanPresenceBySession(options?: { fresh?: boolean }): Map<string, PanePresenceInput[]> {
+    const snapshot = this.getSnapshot(options);
+    return new Map(
+      [...snapshot.presenceBySession.entries()].map(([session, paneAgents]) => [
+        session,
+        paneAgents.map((paneAgent) => ({ ...paneAgent })),
+      ]),
+    );
+  }
+
+  size(now = this.now()): number {
+    return this.registry.size(now);
+  }
+
+  invalidate(): void {
+    this.snapshot = null;
+  }
+
+  private now(): number {
+    return this.deps.now?.() ?? Date.now();
+  }
+
+  private getSnapshot(options?: { fresh?: boolean }): PiLiveSnapshot {
+    const now = this.now();
+    if (!options?.fresh && this.snapshot && now - this.snapshot.builtAt < this.cacheTtlMs) {
+      return this.snapshot;
+    }
+
+    this.registry.prune(now);
+
+    const panes = this.deps.listPanes();
+    const sidebarPaneIds = new Set(this.deps.listSidebarPaneIds());
+    const tree = this.deps.buildProcessTree();
+    const ownersByThreadId = new Map<string, PiThreadOwner | null>();
+
+    for (const pane of panes) {
+      if (sidebarPaneIds.has(pane.paneId)) continue;
+      const matches = this.resolveSessionsForPanePid(pane.pid, tree, now);
+      for (const match of matches) {
+        const owner: PiThreadOwner = {
+          threadId: match.sessionId,
+          session: pane.session,
+          paneId: pane.paneId,
+          pid: match.pid,
+        };
+        const existing = ownersByThreadId.get(match.sessionId);
+        if (!existing) {
+          ownersByThreadId.set(match.sessionId, owner);
+          continue;
+        }
+        if (
+          existing.session !== owner.session
+          || existing.paneId !== owner.paneId
+          || existing.pid !== owner.pid
+        ) {
+          ownersByThreadId.set(match.sessionId, null);
+        }
+      }
+    }
+
+    const presenceBySession = new Map<string, PanePresenceInput[]>();
+    for (const owner of ownersByThreadId.values()) {
+      if (!owner) continue;
+      let sessionPresence = presenceBySession.get(owner.session);
+      if (!sessionPresence) {
+        sessionPresence = [];
+        presenceBySession.set(owner.session, sessionPresence);
+      }
+      sessionPresence.push({
+        agent: "pi",
+        paneId: owner.paneId,
+        threadId: owner.threadId,
+      });
+    }
+
+    this.snapshot = {
+      builtAt: now,
+      ownersByThreadId,
+      presenceBySession,
+    };
+    return this.snapshot;
+  }
+
+  private resolveSessionsForPanePid(
+    panePid: number,
+    tree: ProcessTreeSnapshot,
+    now: number,
+  ): Array<{ pid: number; sessionId: string }> {
+    const piPids = collectDescendantPidsFast(panePid, (comm) => isExactCommand(comm, "pi"), tree);
+    return this.registry.getSessionIdsForPids(piPids, now);
+  }
+}

--- a/packages/runtime/src/server/pi-live-resolver.ts
+++ b/packages/runtime/src/server/pi-live-resolver.ts
@@ -140,8 +140,11 @@ export class PiLiveResolver {
           pid: match.pid,
         };
         const existing = ownersByThreadId.get(match.sessionId);
-        if (!existing) {
+        if (existing === undefined) {
           ownersByThreadId.set(match.sessionId, owner);
+          continue;
+        }
+        if (existing === null) {
           continue;
         }
         if (

--- a/packages/runtime/src/server/pi-runtime-registry.ts
+++ b/packages/runtime/src/server/pi-runtime-registry.ts
@@ -1,0 +1,95 @@
+export interface PiRuntimeInfo {
+  pid: number;
+  ppid?: number;
+  sessionId: string;
+  sessionFile?: string;
+  cwd: string;
+  sessionName?: string;
+  ts: number;
+}
+
+const DEFAULT_TTL_MS = 20_000;
+
+function isPositiveInt(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isOptionalPositiveInt(value: unknown): value is number | undefined {
+  return value === undefined || isPositiveInt(value);
+}
+
+export function parsePiRuntimeInfo(value: unknown, now = Date.now()): PiRuntimeInfo | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+
+  if (!isPositiveInt(raw.pid)) return null;
+  if (!isOptionalPositiveInt(raw.ppid)) return null;
+  if (typeof raw.sessionId !== "string" || raw.sessionId.trim() === "") return null;
+  if (typeof raw.cwd !== "string" || raw.cwd.trim() === "") return null;
+  if (raw.sessionFile !== undefined && typeof raw.sessionFile !== "string") return null;
+  if (raw.sessionName !== undefined && typeof raw.sessionName !== "string") return null;
+
+  const ts = typeof raw.ts === "number" && Number.isFinite(raw.ts) ? raw.ts : now;
+
+  return {
+    pid: raw.pid,
+    ...(raw.ppid !== undefined && { ppid: raw.ppid }),
+    sessionId: raw.sessionId,
+    ...(typeof raw.sessionFile === "string" && raw.sessionFile !== "" && { sessionFile: raw.sessionFile }),
+    cwd: raw.cwd,
+    ...(typeof raw.sessionName === "string" && raw.sessionName !== "" && { sessionName: raw.sessionName }),
+    ts,
+  };
+}
+
+export class PiRuntimeRegistry {
+  private readonly byPid = new Map<number, PiRuntimeInfo>();
+
+  constructor(private readonly ttlMs: number = DEFAULT_TTL_MS) {}
+
+  upsert(info: PiRuntimeInfo): void {
+    this.byPid.set(info.pid, info);
+  }
+
+  delete(pid: number): boolean {
+    return this.byPid.delete(pid);
+  }
+
+  get(pid: number, now = Date.now()): PiRuntimeInfo | null {
+    const info = this.byPid.get(pid);
+    if (!info) return null;
+    if (now - info.ts > this.ttlMs) {
+      this.byPid.delete(pid);
+      return null;
+    }
+    return info;
+  }
+
+  prune(now = Date.now()): boolean {
+    let changed = false;
+    for (const [pid, info] of this.byPid) {
+      if (now - info.ts <= this.ttlMs) continue;
+      this.byPid.delete(pid);
+      changed = true;
+    }
+    return changed;
+  }
+
+  getSessionIdsForPids(pids: Iterable<number>, now = Date.now()): Array<{ pid: number; sessionId: string }> {
+    const matches: Array<{ pid: number; sessionId: string }> = [];
+    const seen = new Set<string>();
+    for (const pid of pids) {
+      const info = this.get(pid, now);
+      if (!info) continue;
+      if (seen.has(info.sessionId)) continue;
+      seen.add(info.sessionId);
+      matches.push({ pid, sessionId: info.sessionId });
+    }
+    return matches;
+  }
+
+  size(now = Date.now()): number {
+    this.prune(now);
+    return this.byPid.size;
+  }
+}

--- a/packages/runtime/test/agent-tracker.test.ts
+++ b/packages/runtime/test/agent-tracker.test.ts
@@ -127,6 +127,18 @@ describe("AgentTracker", () => {
     expect(tracker.getUnseen()).not.toContain("sess-1");
   });
 
+  test("dedupeInstanceToSession removes duplicate watcher instance from other sessions", () => {
+    tracker.applyEvent(event({ session: "sess-1", agent: "pi", threadId: "shared", status: "running" }));
+    tracker.applyEvent(event({ session: "sess-2", agent: "pi", threadId: "shared", status: "running" }));
+
+    const changed = tracker.dedupeInstanceToSession("sess-2", "pi", "shared");
+
+    expect(changed).toBe(true);
+    expect(tracker.getAgents("sess-1")).toHaveLength(0);
+    expect(tracker.getAgents("sess-2")).toHaveLength(1);
+    expect(tracker.getAgents("sess-2")[0]!.threadId).toBe("shared");
+  });
+
   // --- pruneStuck ---
 
   test("pruneStuck removes running states older than timeout", () => {
@@ -390,16 +402,45 @@ describe("AgentTracker", () => {
       expect(agents[0]!.liveness).toBe("alive");
     });
 
-    test("cleans up synthetic entry when watcher creates entry for same agent", () => {
-      // Scanner detects agent before watcher → creates synthetic
+    test("enriches exact watcher entry when pane presence includes threadId", () => {
+      tracker.applyEvent(event({ session: "sess-1", agent: "pi", threadId: "thread-a", status: "running" }));
+      tracker.applyEvent(event({ session: "sess-1", agent: "pi", threadId: "thread-b", status: "running" }));
+
+      const changed = tracker.applyPanePresence("sess-1", [
+        { agent: "pi", paneId: "%31", threadId: "thread-b" },
+      ]);
+
+      expect(changed).toBe(true);
+      const agents = tracker.getAgents("sess-1");
+      expect(agents.find((agent) => agent.threadId === "thread-a")?.paneId).toBeUndefined();
+      expect(agents.find((agent) => agent.threadId === "thread-b")?.paneId).toBe("%31");
+    });
+
+    test("keeps ambiguous same-agent watcher entries separate when pane presence has no threadId", () => {
+      tracker.applyEvent(event({ session: "sess-1", agent: "pi", threadId: "thread-a", status: "running" }));
+      tracker.applyEvent(event({ session: "sess-1", agent: "pi", threadId: "thread-b", status: "running" }));
+
+      const changed = tracker.applyPanePresence("sess-1", [
+        { agent: "pi", paneId: "%21" },
+      ]);
+
+      expect(changed).toBe(true);
+      const agents = tracker.getAgents("sess-1");
+      expect(agents).toHaveLength(3);
+      expect(agents.filter((agent) => agent.agent === "pi" && agent.threadId)).toHaveLength(2);
+      expect(agents.find((agent) => agent.threadId === undefined)?.paneId).toBe("%21");
+    });
+
+    test("cleans up synthetic entry when watcher creates entry for same exact thread", () => {
       tracker.applyPanePresence("sess-1", [
-        { agent: "claude-code", paneId: "%21" },
+        { agent: "pi", paneId: "%21", threadId: "abc" },
       ]);
       expect(tracker.getAgents("sess-1").length).toBe(1);
       expect(tracker.getAgents("sess-1")[0]!.paneId).toBe("%21");
+      expect(tracker.getAgents("sess-1")[0]!.threadId).toBe("abc");
 
-      // Watcher catches up → creates entry with threadId, auto-cleans synthetic
-      tracker.applyEvent(event({ session: "sess-1", agent: "claude-code", threadId: "abc", status: "running" }));
+      // Watcher catches up → creates entry with same threadId, auto-cleans synthetic
+      tracker.applyEvent(event({ session: "sess-1", agent: "pi", threadId: "abc", status: "running" }));
       const agents = tracker.getAgents("sess-1");
       expect(agents.length).toBe(1);
       expect(agents[0]!.threadId).toBe("abc");

--- a/packages/runtime/test/pi-live-resolver.test.ts
+++ b/packages/runtime/test/pi-live-resolver.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { AgentTracker } from "../src/agents/tracker";
+import { canonicalizeAgentEvent } from "../src/server/agent-ownership";
+import type { ProcessTreeSnapshot } from "../src/server/pi-live-resolver";
+import { PiLiveResolver } from "../src/server/pi-live-resolver";
+import { PiRuntimeRegistry } from "../src/server/pi-runtime-registry";
+
+function buildProcessTree(rows: Array<{ pid: number; ppid: number; comm: string }>): ProcessTreeSnapshot {
+  const childrenOf = new Map<number, number[]>();
+  const commOf = new Map<number, string>();
+
+  for (const row of rows) {
+    commOf.set(row.pid, row.comm.toLowerCase());
+    const children = childrenOf.get(row.ppid) ?? [];
+    children.push(row.pid);
+    childrenOf.set(row.ppid, children);
+  }
+
+  return { childrenOf, commOf };
+}
+
+describe("PiLiveResolver", () => {
+  test("resolves unambiguous live thread ownership and pane presence", () => {
+    const registry = new PiRuntimeRegistry(10_000);
+    const resolver = new PiLiveResolver({
+      listPanes: () => [{ session: "CodexBar", paneId: "%4", pid: 100 }],
+      listSidebarPaneIds: () => [],
+      buildProcessTree: () => buildProcessTree([
+        { pid: 201, ppid: 100, comm: "pi" },
+      ]),
+      now: () => 1000,
+    }, registry, 10_000);
+
+    resolver.upsert({ pid: 201, sessionId: "thread-1", cwd: "/tmp/project", ts: 1000 });
+
+    expect(resolver.resolveThreadOwner("thread-1")).toEqual({
+      threadId: "thread-1",
+      session: "CodexBar",
+      paneId: "%4",
+      pid: 201,
+    });
+    expect([...resolver.scanPresenceBySession().entries()]).toEqual([
+      ["CodexBar", [{ agent: "pi", paneId: "%4", threadId: "thread-1" }]],
+    ]);
+  });
+
+  test("treats the same thread appearing in multiple panes as ambiguous", () => {
+    const registry = new PiRuntimeRegistry(10_000);
+    const resolver = new PiLiveResolver({
+      listPanes: () => [
+        { session: "opensessions", paneId: "%4", pid: 100 },
+        { session: "CodexBar", paneId: "%7", pid: 300 },
+      ],
+      listSidebarPaneIds: () => [],
+      buildProcessTree: () => buildProcessTree([
+        { pid: 201, ppid: 100, comm: "pi" },
+        { pid: 202, ppid: 300, comm: "pi" },
+      ]),
+      now: () => 1000,
+    }, registry, 10_000);
+
+    resolver.upsert({ pid: 201, sessionId: "thread-1", cwd: "/tmp/a", ts: 1000 });
+    resolver.upsert({ pid: 202, sessionId: "thread-1", cwd: "/tmp/b", ts: 1000 });
+
+    expect(resolver.resolveThreadOwner("thread-1")).toBeNull();
+    expect([...resolver.scanPresenceBySession().entries()]).toEqual([]);
+  });
+
+  test("canonicalizes cwd-mismatched Pi events to the live pane owner and dedupes tracker state", () => {
+    const registry = new PiRuntimeRegistry(10_000);
+    const resolver = new PiLiveResolver({
+      listPanes: () => [{ session: "CodexBar", paneId: "%4", pid: 100 }],
+      listSidebarPaneIds: () => [],
+      buildProcessTree: () => buildProcessTree([
+        { pid: 201, ppid: 100, comm: "pi" },
+      ]),
+      now: () => 1000,
+    }, registry, 10_000);
+    resolver.upsert({ pid: 201, sessionId: "thread-1", cwd: "/Users/guti/projects/opensessions", ts: 1000 });
+
+    const tracker = new AgentTracker();
+    tracker.applyEvent({
+      agent: "pi",
+      session: "opensessions",
+      status: "running",
+      ts: 900,
+      threadId: "thread-1",
+    });
+
+    const canonical = canonicalizeAgentEvent(
+      {
+        agent: "pi",
+        session: "opensessions",
+        status: "running",
+        ts: 1000,
+        threadId: "thread-1",
+      },
+      (agent, threadId) => {
+        if (agent !== "pi" || !threadId) return null;
+        const owner = resolver.resolveThreadOwner(threadId);
+        return owner ? { session: owner.session, paneId: owner.paneId } : null;
+      },
+    );
+
+    tracker.dedupeInstanceToSession(canonical.session, canonical.agent, canonical.threadId);
+    tracker.applyEvent(canonical);
+
+    expect(tracker.getAgents("opensessions")).toHaveLength(0);
+    expect(tracker.getAgents("CodexBar")).toHaveLength(1);
+    expect(tracker.getAgents("CodexBar")[0]).toMatchObject({
+      agent: "pi",
+      session: "CodexBar",
+      threadId: "thread-1",
+      paneId: "%4",
+    });
+  });
+});

--- a/packages/runtime/test/pi-live-resolver.test.ts
+++ b/packages/runtime/test/pi-live-resolver.test.ts
@@ -66,6 +66,31 @@ describe("PiLiveResolver", () => {
     expect([...resolver.scanPresenceBySession().entries()]).toEqual([]);
   });
 
+  test("keeps ambiguous thread ownership sticky within a snapshot", () => {
+    const registry = new PiRuntimeRegistry(10_000);
+    const resolver = new PiLiveResolver({
+      listPanes: () => [
+        { session: "opensessions", paneId: "%4", pid: 100 },
+        { session: "CodexBar", paneId: "%7", pid: 300 },
+        { session: "opensessions", paneId: "%9", pid: 500 },
+      ],
+      listSidebarPaneIds: () => [],
+      buildProcessTree: () => buildProcessTree([
+        { pid: 201, ppid: 100, comm: "pi" },
+        { pid: 202, ppid: 300, comm: "pi" },
+        { pid: 203, ppid: 500, comm: "pi" },
+      ]),
+      now: () => 1000,
+    }, registry, 10_000);
+
+    resolver.upsert({ pid: 201, sessionId: "thread-1", cwd: "/tmp/a", ts: 1000 });
+    resolver.upsert({ pid: 202, sessionId: "thread-1", cwd: "/tmp/b", ts: 1000 });
+    resolver.upsert({ pid: 203, sessionId: "thread-1", cwd: "/tmp/c", ts: 1000 });
+
+    expect(resolver.resolveThreadOwner("thread-1")).toBeNull();
+    expect([...resolver.scanPresenceBySession().entries()]).toEqual([]);
+  });
+
   test("canonicalizes cwd-mismatched Pi events to the live pane owner and dedupes tracker state", () => {
     const registry = new PiRuntimeRegistry(10_000);
     const resolver = new PiLiveResolver({

--- a/packages/runtime/test/pi-runtime-registry.test.ts
+++ b/packages/runtime/test/pi-runtime-registry.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "bun:test";
+import { PiRuntimeRegistry, parsePiRuntimeInfo } from "../src/server/pi-runtime-registry";
+
+describe("parsePiRuntimeInfo", () => {
+  test("parses a valid payload", () => {
+    const info = parsePiRuntimeInfo({
+      pid: 123,
+      ppid: 45,
+      sessionId: "sess-123",
+      sessionFile: "/tmp/session.jsonl",
+      cwd: "/tmp/project",
+      sessionName: "demo",
+      ts: 1000,
+    });
+
+    expect(info).toEqual({
+      pid: 123,
+      ppid: 45,
+      sessionId: "sess-123",
+      sessionFile: "/tmp/session.jsonl",
+      cwd: "/tmp/project",
+      sessionName: "demo",
+      ts: 1000,
+    });
+  });
+
+  test("rejects invalid payloads", () => {
+    expect(parsePiRuntimeInfo(null)).toBeNull();
+    expect(parsePiRuntimeInfo({ pid: 0, sessionId: "x", cwd: "/tmp" })).toBeNull();
+    expect(parsePiRuntimeInfo({ pid: 1, sessionId: "", cwd: "/tmp" })).toBeNull();
+    expect(parsePiRuntimeInfo({ pid: 1, sessionId: "x", cwd: 42 })).toBeNull();
+    expect(parsePiRuntimeInfo({ pid: 1, sessionId: "x", cwd: "/tmp", sessionName: 42 })).toBeNull();
+  });
+});
+
+describe("PiRuntimeRegistry", () => {
+  test("stores and returns live entries", () => {
+    const registry = new PiRuntimeRegistry(10_000);
+    registry.upsert({ pid: 123, sessionId: "sess-123", cwd: "/tmp/project", ts: 1000 });
+
+    expect(registry.get(123, 1500)?.sessionId).toBe("sess-123");
+    expect(registry.size(1500)).toBe(1);
+  });
+
+  test("expires stale entries on read", () => {
+    const registry = new PiRuntimeRegistry(1000);
+    registry.upsert({ pid: 123, sessionId: "sess-123", cwd: "/tmp/project", ts: 1000 });
+
+    expect(registry.get(123, 2501)).toBeNull();
+    expect(registry.size(2501)).toBe(0);
+  });
+
+  test("dedupes session ids when resolving pid matches", () => {
+    const registry = new PiRuntimeRegistry(10_000);
+    registry.upsert({ pid: 123, sessionId: "sess-a", cwd: "/tmp/a", ts: 1000 });
+    registry.upsert({ pid: 124, sessionId: "sess-a", cwd: "/tmp/a", ts: 1000 });
+    registry.upsert({ pid: 125, sessionId: "sess-b", cwd: "/tmp/b", ts: 1000 });
+
+    expect(registry.getSessionIdsForPids([123, 124, 125], 1500)).toEqual([
+      { pid: 123, sessionId: "sess-a" },
+      { pid: 125, sessionId: "sess-b" },
+    ]);
+  });
+
+  test("deletes entries explicitly", () => {
+    const registry = new PiRuntimeRegistry(10_000);
+    registry.upsert({ pid: 123, sessionId: "sess-123", cwd: "/tmp/project", ts: 1000 });
+
+    expect(registry.delete(123)).toBe(true);
+    expect(registry.get(123, 1000)).toBeNull();
+  });
+});

--- a/packages/runtime/test/pi-watcher.test.ts
+++ b/packages/runtime/test/pi-watcher.test.ts
@@ -70,6 +70,7 @@ describe("PiAgentWatcher", () => {
     events = [];
     ctx = {
       resolveSession: (dir) => dir === "/projects/myapp" ? "myapp-session" : null,
+      resolveThreadOwner: () => null,
       emit: (event) => events.push(event),
     };
 
@@ -176,5 +177,56 @@ describe("PiAgentWatcher", () => {
     expect(events).toHaveLength(1);
     expect(events[0]!.status).toBe("running");
     expect(events[0]!.threadId).toBe("abcdefab-cdef-cdef-cdef-abcdefabcdef");
+  });
+
+  test("falls back to live thread ownership when cwd does not map to a mux session", async () => {
+    ctx.resolveSession = () => null;
+    ctx.resolveThreadOwner = (agent, threadId) =>
+      agent === "pi" && threadId === "12345678-1234-1234-1234-123456789abc"
+        ? { session: "myapp-session", paneId: "%4" }
+        : null;
+
+    watcher.start(ctx);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.session).toBe("myapp-session");
+    expect(events[0]!.threadId).toBe("12345678-1234-1234-1234-123456789abc");
+    expect(events[0]!.status).toBe("running");
+  });
+
+  test("uses live thread ownership even when the transcript header has no cwd", async () => {
+    writeFileSync(sessionFile,
+      JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "12345678-1234-1234-1234-123456789abc",
+        timestamp: "2026-03-27T12:00:00.000Z",
+      }) + "\n" +
+      JSON.stringify({
+        type: "message",
+        id: "msg-user-1",
+        parentId: null,
+        timestamp: "2026-03-27T12:00:01.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Fix the watcher status mapping" }],
+          timestamp: 1774612801000,
+        },
+      }) + "\n",
+    );
+
+    ctx.resolveSession = () => null;
+    ctx.resolveThreadOwner = (agent, threadId) =>
+      agent === "pi" && threadId === "12345678-1234-1234-1234-123456789abc"
+        ? { session: "myapp-session", paneId: "%4" }
+        : null;
+
+    watcher.start(ctx);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.session).toBe("myapp-session");
+    expect(events[0]!.status).toBe("running");
   });
 });


### PR DESCRIPTION
## Summary
- add a Pi runtime registry + extension heartbeat so live `pi` processes can be mapped to exact tmux panes
- canonicalize Pi thread ownership against live pane data, dedupe cross-session watcher instances, and preserve exact focus/kill targeting
- harden sidebar behavior by ignoring background sidebar focus reports and cleaning up duplicate sidebar panes per window

## Details
This PR makes Pi support first-class in opensessions:
- multiple Pi panes in a single tmux session are tracked independently by `threadId`
- watcher events fall back to live pane ownership when transcript `cwd` does not resolve cleanly
- live pane ownership is treated as authoritative when watcher cwd-based session resolution disagrees
- Pi pane focus/kill resolves exact panes conservatively

It also refactors the implementation to be cleaner:
- extracts Pi live ownership resolution into `pi-live-resolver.ts`
- extracts event canonicalization into `agent-ownership.ts`
- generalizes watcher ownership lookup to `resolveThreadOwner()`

## Validation
- `cd packages/runtime && bun test`
- manual verification against live tmux + Pi panes:
  - multiple Pi panes show up correctly in session detail
  - exact focus-agent-pane and kill-agent-pane target the right Pi pane
  - duplicate cross-session Pi watcher entries are removed
  - previously stuck Pi status updates now flow through for cwd-mismatched panes
