### PR TITLE
feat(tmux): add even-horizontal layout shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Then remove the `set -g @plugin 'Ataraxy-Labs/opensessions'` line from `~/.tmux.
 - Session context in the UI: branch in the list, working directory in the detail panel, thread names, and detected localhost ports.
 - Programmatic metadata API: agents and scripts push status, progress, and logs to the sidebar via HTTP.
 - Fast switching with `j`/`k`, arrows, `Tab`, `1`-`9`, session reordering, hide/restore, creation, and kill actions.
-- `prefix o → s` and `prefix o → t` for sidebar focus and toggle, `prefix o → 1` through `9` for quick switching, optional no-prefix shortcuts, in-app theme switching, and plugin hooks for more mux providers or watchers.
+- `prefix o → s` and `prefix o → t` for sidebar focus and toggle, `prefix o → e` for sidebar-safe `even-horizontal` layout in the current window, `prefix o → 1` through `9` for quick switching, optional no-prefix shortcuts, in-app theme switching, and plugin hooks for more mux providers or watchers.
 - Bun workspace, source-first execution, and a local server on `127.0.0.1:7391`.
 
 ## Programmatic API

--- a/apps/tui/src/index.tsx
+++ b/apps/tui/src/index.tsx
@@ -221,6 +221,7 @@ function getLocalWindowId(): string | null {
 function App() {
   const renderer = useRenderer();
   const startupSessionName = getLocalSessionName();
+  const startupWindowId = getLocalWindowId();
 
   // --- Theme state (driven by server) ---
   const [theme, setTheme] = createSignal<Theme>(resolveTheme(undefined));
@@ -291,6 +292,8 @@ function App() {
   const [clientTty, setClientTty] = createSignal(getClientTty());
   let ws: WebSocket | null = null;
   let startupFocusSynced = false;
+  let lastIdentifiedSessionName: string | null = startupSessionName;
+  let lastIdentifiedWindowId: string | null = startupWindowId;
   let detailResizeStartY = 0;
   let detailResizeStartHeight = DEFAULT_DETAIL_PANEL_HEIGHT;
 
@@ -306,6 +309,11 @@ function App() {
     // Optimistic local update — makes rapid Tab repeat instant by removing
     // the server/hook round-trip from the next-Tab decision.
     // The server's focus/state broadcast will reconcile if needed.
+    // Also update mySession optimistically: after a successful tmux switch,
+    // this sidebar client now belongs to the target session. Without this,
+    // resolveSyncedFocus can snap focus back to the previous local session
+    // during the handoff window before the server replies with your-session.
+    setMySession(name);
     setCurrentSession(name);
     setFocusedSession(name);
     setPanelFocus("sessions");
@@ -315,13 +323,25 @@ function App() {
 
   function reIdentify() {
     const sessionName = getLocalSessionName();
-    if (!sessionName) return;
+    if (!sessionName || sessionName === "_os_stash") return;
     const windowId = getLocalWindowId() ?? undefined;
+
+    lastIdentifiedSessionName = sessionName;
+    lastIdentifiedWindowId = windowId ?? null;
 
     if (muxCtx.type === "tmux") {
       send({ type: "identify-pane", paneId: muxCtx.paneId, sessionName, windowId });
     } else if (muxCtx.type === "zellij") {
       send({ type: "identify-pane", paneId: muxCtx.paneId, sessionName });
+    }
+  }
+
+  function maybeReIdentify() {
+    const sessionName = getLocalSessionName();
+    const windowId = getLocalWindowId();
+    if (!sessionName || sessionName === "_os_stash") return;
+    if (sessionName !== lastIdentifiedSessionName || windowId !== lastIdentifiedWindowId) {
+      reIdentify();
     }
   }
 
@@ -557,9 +577,10 @@ function App() {
         setTerminalWidth(Math.max(0, width));
         if (width !== lastReportedWidth) {
           lastReportedWidth = width;
-          const my = mySession();
+          const liveSession = getLocalSessionName();
           const current = currentSession();
-          if (my && current && my !== current) return;
+          if (!liveSession || liveSession === "_os_stash") return;
+          if (current && liveSession !== current) return;
           send({ type: "report-width", width });
         }
       };
@@ -572,7 +593,10 @@ function App() {
         const msg = JSON.parse(event.data as string) as ServerMessage;
         let startupFocusToPublish: string | null = null;
         batch(() => {
-          const localSessionName = mySession() ?? startupSessionName;
+          const liveLocalSessionName = getLocalSessionName();
+          const localSessionName = liveLocalSessionName && liveLocalSessionName !== "_os_stash"
+            ? liveLocalSessionName
+            : mySession() ?? startupSessionName;
 
           if (msg.type === "state") {
             const startupFocus = !startupFocusSynced
@@ -607,7 +631,8 @@ function App() {
             setInitLabel(msg.initLabel ?? "");
           } else if (msg.type === "focus") {
             if (!initializing()) {
-              setFocusedSession(resolveSyncedFocus(msg.focusedSession, msg.currentSession, localSessionName));
+              const nextFocusedSession = resolveSyncedFocus(msg.focusedSession, msg.currentSession, localSessionName);
+              setFocusedSession(nextFocusedSession);
               setCurrentSession(msg.currentSession);
             }
           } else if (msg.type === "your-session") {
@@ -626,6 +651,8 @@ function App() {
             reIdentify();
           }
         });
+
+        maybeReIdentify();
 
         if (startupFocusToPublish) {
           send({ type: "focus-session", name: startupFocusToPublish });
@@ -877,8 +904,6 @@ function App() {
               theme={theme}
               statusColors={S}
               onSelect={() => {
-                setFocusedSession(session.name);
-                send({ type: "focus-session", name: session.name });
                 switchToSession(session.name);
               }}
             />

--- a/docs/how-to/set-up-ghostty-shortcuts.md
+++ b/docs/how-to/set-up-ghostty-shortcuts.md
@@ -2,7 +2,7 @@
 
 This guide shows how to add macOS-native keyboard shortcuts in [Ghostty](https://ghostty.org) that control the opensessions sidebar without leaving the keyboard.
 
-The opensessions tmux plugin registers a command table (`prefix o → s/t/1-9`) for manual use. It also registers direct prefix bindings (`C-s`, `C-t`, `M-1..9`) that terminal emulators can send programmatically. The Ghostty config below uses those direct bindings so each shortcut is a single action.
+The opensessions tmux plugin registers a command table (`prefix o → s/t/e/1-9`) for manual use. It also registers direct prefix bindings (`C-s`, `C-t`, `M-1..9`) that terminal emulators can send programmatically. The `e` layout action is currently command-table only. The Ghostty config below uses the direct bindings so each shortcut is a single action.
 
 ## Prerequisites
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -93,6 +93,7 @@ The plugin registers these prefix bindings automatically:
 | --- | --- |
 | `prefix o → s` | Reveal and focus the sidebar |
 | `prefix o → t` | Toggle the sidebar |
+| `prefix o → e` | Spread non-sidebar panes in the current window using `even-horizontal` |
 | `prefix o → 1` through `prefix o → 9` | Switch to visible session by index |
 
 Minimal install:

--- a/docs/reference/features-and-keybindings.md
+++ b/docs/reference/features-and-keybindings.md
@@ -77,6 +77,7 @@ Clicking a detected port opens `http://localhost:<port>`.
 | --- | --- |
 | `prefix o → s` | Reveal and focus the sidebar pane |
 | `prefix o → t` | Toggle the sidebar |
+| `prefix o → e` | Spread non-sidebar panes in the current window using `even-horizontal` |
 | `prefix o → 1` through `prefix o → 9` | Switch directly to the visible session indices |
 | Configurable `@opensessions-focus-global-key` such as `Alt-s` | Reveal and focus the sidebar pane from any tmux pane |
 | Configurable `@opensessions-index-keys` such as `Alt-1` through `Alt-9` | Switch directly to the visible session indices from any tmux pane |

--- a/docs/tutorials/get-started-in-tmux.md
+++ b/docs/tutorials/get-started-in-tmux.md
@@ -1,6 +1,6 @@
 # Get Started In tmux
 
-This tutorial gets opensessions running as a real tmux sidebar, either through TPM or from a local clone. By the end, you will be able to press `prefix o → s` to open the sidebar, toggle it with `prefix o → t`, switch directly with `prefix o → 1` through `prefix o → 9`, and see agent and Git state update live.
+This tutorial gets opensessions running as a real tmux sidebar, either through TPM or from a local clone. By the end, you will be able to press `prefix o → s` to open the sidebar, toggle it with `prefix o → t`, spread non-sidebar panes with `prefix o → e`, switch directly with `prefix o → 1` through `prefix o → 9`, and see agent and Git state update live.
 
 ## Prerequisites
 
@@ -81,6 +81,7 @@ Recommended shortcut scheme:
 
 - `prefix o → s` reveals and focuses the sidebar pane.
 - `prefix o → t` toggles the sidebar.
+- `prefix o → e` spreads non-sidebar panes in the current window using `even-horizontal`.
 - `prefix o → 1` through `prefix o → 9` switch directly to the visible session indices.
 
 If you use a terminal or window manager setup where no-prefix bindings are safe, you can also set `@opensessions-focus-global-key` and `@opensessions-index-keys`, but they are left unset by default to avoid conflicts.

--- a/integrations/tmux-plugin/scripts/even-horizontal-common.sh
+++ b/integrations/tmux-plugin/scripts/even-horizontal-common.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+# Pure helpers for parsing pane row snapshots produced with:
+#   #{pane_id}|#{pane_title}|#{pane_width}|#{pane_left}|#{pane_right}|#{pane_active}
+
+count_sidebar_panes() {
+  pane_rows="$1"
+  title="${2:-opensessions-sidebar}"
+  printf '%s\n' "$pane_rows" | awk -F '|' -v title="$title" '$2 == title { count++ } END { print count + 0 }'
+}
+
+count_non_sidebar_panes() {
+  pane_rows="$1"
+  title="${2:-opensessions-sidebar}"
+  printf '%s\n' "$pane_rows" | awk -F '|' -v title="$title" '$2 != title { count++ } END { print count + 0 }'
+}
+
+extract_sidebar_info() {
+  pane_rows="$1"
+  title="${2:-opensessions-sidebar}"
+  printf '%s\n' "$pane_rows" | awk -F '|' -v title="$title" '$2 == title { print $1 "|" $3 "|" $4 "|" $5 "|" $6; exit }'
+}
+
+detect_sidebar_side() {
+  pane_rows="$1"
+  sidebar_left="$2"
+  sidebar_right="$3"
+  title="${4:-opensessions-sidebar}"
+
+  printf '%s\n' "$pane_rows" | awk -F '|' -v title="$title" -v sleft="$sidebar_left" -v sright="$sidebar_right" '
+    $2 == title { next }
+    {
+      if (min_left == "" || $4 < min_left) min_left = $4;
+      if (max_right == "" || $5 > max_right) max_right = $5;
+    }
+    END {
+      if (min_left != "" && sright < min_left) print "left";
+      else if (max_right != "" && sleft > max_right) print "right";
+    }
+  '
+}

--- a/integrations/tmux-plugin/scripts/even-horizontal.sh
+++ b/integrations/tmux-plugin/scripts/even-horizontal.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env sh
+# Spread non-sidebar panes in the current tmux window using even-horizontal,
+# while preserving the opensessions sidebar pane if present.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/sidebar-common.sh"
+. "$SCRIPT_DIR/even-horizontal-common.sh"
+. "$SCRIPT_DIR/server-common.sh"
+
+pane_rows_for_window() {
+  window_id="$1"
+  tmux list-panes -t "$window_id" -F "#{pane_id}${PANE_FIELD_SEP}#{pane_title}${PANE_FIELD_SEP}#{pane_width}${PANE_FIELD_SEP}#{pane_left}${PANE_FIELD_SEP}#{pane_right}${PANE_FIELD_SEP}#{pane_active}" 2>/dev/null
+}
+
+active_pane_in_window() {
+  tmux list-panes -t "$1" -F "#{pane_id}${PANE_FIELD_SEP}#{pane_active}" 2>/dev/null | awk -F "$PANE_FIELD_SEP" '$2 == "1" { print $1; exit }'
+}
+
+restore_focus() {
+  preferred_pane_id="$1"
+  sidebar_pane_id="$2"
+  sidebar_active="$3"
+
+  if [ "$sidebar_active" = "1" ] && [ -n "$sidebar_pane_id" ]; then
+    tmux select-pane -t "$sidebar_pane_id" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  if [ -n "$preferred_pane_id" ]; then
+    tmux select-pane -t "$preferred_pane_id" >/dev/null 2>&1 || true
+  fi
+}
+
+suppress_sidebar_width_reports() {
+  server_alive || return 0
+  curl -s -o /dev/null -m 0.2 --connect-timeout 0.1 -X POST "http://${HOST}:${PORT}/suppress-width-reports?ms=2000" >/dev/null 2>&1 || true
+}
+
+WINDOW_ID="${1:-$(current_window_id)}"
+[ -n "$WINDOW_ID" ] || exit 0
+
+CURRENT_PANE_ID="${2:-$(current_pane_id)}"
+CURRENT_PANE_ID="${CURRENT_PANE_ID:-$(active_pane_in_window "$WINDOW_ID")}"
+
+PANE_ROWS="$(pane_rows_for_window "$WINDOW_ID")"
+[ -n "$PANE_ROWS" ] || exit 0
+
+SIDEBAR_COUNT="$(count_sidebar_panes "$PANE_ROWS" "$SIDEBAR_PANE_TITLE")"
+NON_SIDEBAR_COUNT="$(count_non_sidebar_panes "$PANE_ROWS" "$SIDEBAR_PANE_TITLE")"
+
+# Ambiguous sidebar state: do nothing rather than guess.
+if [ "$SIDEBAR_COUNT" -gt 1 ]; then
+  tmux switch-client -T root >/dev/null 2>&1 || true
+  exit 0
+fi
+
+# Need at least two non-sidebar panes for even-horizontal to have an effect.
+if [ "$NON_SIDEBAR_COUNT" -lt 2 ]; then
+  tmux switch-client -T root >/dev/null 2>&1 || true
+  exit 0
+fi
+
+if [ "$SIDEBAR_COUNT" -eq 0 ]; then
+  tmux select-layout -t "$WINDOW_ID" even-horizontal >/dev/null 2>&1 || exit 0
+  restore_focus "$CURRENT_PANE_ID" "" "0"
+  tmux switch-client -T root >/dev/null 2>&1 || true
+  exit 0
+fi
+
+SIDEBAR_INFO="$(extract_sidebar_info "$PANE_ROWS" "$SIDEBAR_PANE_TITLE")"
+SIDEBAR_PANE_ID="$(printf '%s' "$SIDEBAR_INFO" | awk -F "$PANE_FIELD_SEP" '{ print $1 }')"
+SIDEBAR_WIDTH="$(printf '%s' "$SIDEBAR_INFO" | awk -F "$PANE_FIELD_SEP" '{ print $2 }')"
+SIDEBAR_LEFT="$(printf '%s' "$SIDEBAR_INFO" | awk -F "$PANE_FIELD_SEP" '{ print $3 }')"
+SIDEBAR_RIGHT="$(printf '%s' "$SIDEBAR_INFO" | awk -F "$PANE_FIELD_SEP" '{ print $4 }')"
+SIDEBAR_ACTIVE="$(printf '%s' "$SIDEBAR_INFO" | awk -F "$PANE_FIELD_SEP" '{ print $5 }')"
+SIDEBAR_SIDE="$(detect_sidebar_side "$PANE_ROWS" "$SIDEBAR_LEFT" "$SIDEBAR_RIGHT" "$SIDEBAR_PANE_TITLE")"
+
+[ -n "$SIDEBAR_PANE_ID" ] || exit 0
+[ -n "$SIDEBAR_WIDTH" ] || exit 0
+[ -n "$SIDEBAR_SIDE" ] || exit 0
+
+suppress_sidebar_width_reports
+stash_sidebar_pane "$SIDEBAR_PANE_ID" || exit 0
+
+tmux select-layout -t "$WINDOW_ID" even-horizontal >/dev/null 2>&1 || exit 0
+restore_sidebar_pane "$SIDEBAR_PANE_ID" "$WINDOW_ID" "$SIDEBAR_SIDE" "$SIDEBAR_WIDTH" || exit 0
+restore_focus "$CURRENT_PANE_ID" "$SIDEBAR_PANE_ID" "$SIDEBAR_ACTIVE"
+
+tmux switch-client -T root >/dev/null 2>&1 || true

--- a/integrations/tmux-plugin/scripts/sidebar-common.sh
+++ b/integrations/tmux-plugin/scripts/sidebar-common.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+
+SIDEBAR_PANE_TITLE="opensessions-sidebar"
+STASH_SESSION="_os_stash"
+PANE_FIELD_SEP='|'
+
+current_window_id() {
+  tmux display-message -p '#{window_id}' 2>/dev/null || true
+}
+
+current_pane_id() {
+  tmux display-message -p '#{pane_id}' 2>/dev/null || true
+}
+
+ensure_stash() {
+  tmux has-session -t "$STASH_SESSION" 2>/dev/null && return 0
+  tmux new-session -d -s "$STASH_SESSION" -x 80 -y 24 >/dev/null 2>&1
+}
+
+last_stash_window() {
+  tmux list-windows -t "$STASH_SESSION" -F '#{window_id}' 2>/dev/null | awk 'NF { last = $0 } END { print last }'
+}
+
+stash_sidebar_pane() {
+  pane_id="$1"
+  ensure_stash || return 1
+
+  target="$(last_stash_window)"
+  target="${target:-${STASH_SESSION}:}"
+  tmux resize-window -t "$target" -x 200 -y 200 >/dev/null 2>&1 || true
+
+  if tmux join-pane -d -s "$pane_id" -t "$target" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  tmux new-window -d -t "${STASH_SESSION}:" >/dev/null 2>&1 || return 1
+  target="$(last_stash_window)"
+  target="${target:-${STASH_SESSION}:}"
+  tmux resize-window -t "$target" -x 200 -y 200 >/dev/null 2>&1 || true
+  tmux join-pane -d -s "$pane_id" -t "$target" >/dev/null 2>&1
+}
+
+window_edge_pane() {
+  window_id="$1"
+  side="$2"
+  tmux list-panes -t "$window_id" -F "#{pane_id}${PANE_FIELD_SEP}#{pane_left}${PANE_FIELD_SEP}#{pane_right}" 2>/dev/null |
+    awk -F "$PANE_FIELD_SEP" -v side="$side" '
+      side == "left" {
+        if (pane == "" || $2 < edge) { edge = $2; pane = $1 }
+      }
+      side == "right" {
+        if (pane == "" || $3 > edge) { edge = $3; pane = $1 }
+      }
+      END { print pane }
+    '
+}
+
+restore_sidebar_pane() {
+  pane_id="$1"
+  window_id="$2"
+  side="$3"
+  width="$4"
+
+  target_pane_id="$(window_edge_pane "$window_id" "$side")"
+  [ -n "$target_pane_id" ] || return 1
+
+  join_flag="-h"
+  if [ "$side" = "left" ]; then
+    join_flag="-hb"
+  fi
+
+  tmux join-pane "$join_flag" -d -f -l "$width" -s "$pane_id" -t "$target_pane_id" >/dev/null 2>&1 || return 1
+
+  attempt=0
+  while [ "$attempt" -lt 5 ]; do
+    tmux resize-pane -t "$pane_id" -x "$width" >/dev/null 2>&1 || true
+    actual_width="$(tmux display-message -p -t "$pane_id" '#{pane_width}' 2>/dev/null || true)"
+    if [ "$actual_width" = "$width" ]; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.02
+  done
+
+  return 0
+}

--- a/integrations/tmux-plugin/scripts/uninstall.sh
+++ b/integrations/tmux-plugin/scripts/uninstall.sh
@@ -51,6 +51,7 @@ tmux unbind-key "$PREFIX_KEY" 2>/dev/null || true
 # Unbind all keys in the opensessions command table
 tmux unbind-key -T opensessions s 2>/dev/null || true
 tmux unbind-key -T opensessions t 2>/dev/null || true
+tmux unbind-key -T opensessions e 2>/dev/null || true
 for i in 1 2 3 4 5 6 7 8 9; do
   tmux unbind-key -T opensessions "$i" 2>/dev/null || true
 done

--- a/opensessions.tmux
+++ b/opensessions.tmux
@@ -10,6 +10,7 @@
 # Default keybindings:
 #   prefix + o → s   — reveal and focus sidebar
 #   prefix + o → t   — toggle sidebar
+#   prefix + o → e   — spread non-sidebar panes even-horizontal in current window
 #   prefix + o → 1-9 — switch to visible session by index
 #
 # Options (set before TPM init):
@@ -81,12 +82,13 @@ fi
 
 # --- Bind tmux shortcuts ---
 
-# Command table for manual use: prefix o → s/t/1-9
+# Command table for manual use: prefix o → s/t/e/1-9
 if [ -n "$PREFIX_KEY" ]; then
   tmux bind-key "$PREFIX_KEY" switch-client -T "$COMMAND_TABLE"
   tmux bind-key -T "$COMMAND_TABLE" Any switch-client -T root
   tmux bind-key -T "$COMMAND_TABLE" s run-shell "sh '$SCRIPTS_DIR/focus.sh'"
   tmux bind-key -T "$COMMAND_TABLE" t run-shell "sh '$SCRIPTS_DIR/toggle.sh'"
+  tmux bind-key -T "$COMMAND_TABLE" e run-shell "sh '$SCRIPTS_DIR/even-horizontal.sh' '#{window_id}' '#{pane_id}'"
   for i in 1 2 3 4 5 6 7 8 9; do
     tmux bind-key -T "$COMMAND_TABLE" "$i" run-shell "sh '$SCRIPTS_DIR/switch-index.sh' $i"
   done

--- a/packages/runtime/src/server/index.ts
+++ b/packages/runtime/src/server/index.ts
@@ -471,8 +471,13 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
     if (!clientTty) return;
     clientTtyBySession.set(sessionName, clientTty);
     for (const ws of connectedClients) {
-      if (clientTtys.get(ws) !== clientTty) continue;
-      if (windowId && clientWindowIds.get(ws) !== windowId) continue;
+      const existingTty = clientTtys.get(ws);
+      const windowMatches = !!windowId && clientWindowIds.get(ws) === windowId;
+      const ttyMatches = existingTty === clientTty;
+      if (!ttyMatches && !windowMatches) continue;
+      if (windowMatches && existingTty !== clientTty) {
+        clientTtys.set(ws, clientTty);
+      }
       sendYourSession(ws, sessionName, clientTty);
     }
   }
@@ -646,11 +651,56 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
     broadcastFocusOnly(sender);
   }
 
-  function setFocus(name: string, sender?: any) {
-    if (lastState && lastState.sessions.some((s) => s.name === name)) {
-      focusedSession = name;
-      broadcastFocusOnly(sender);
+  function getForegroundClientTtyForWindow(windowId?: string): string | null {
+    if (!windowId) return null;
+    const raw = shell(["tmux", "list-clients", "-F", "#{client_tty}|#{window_id}"]);
+    if (!raw) return null;
+    for (const line of raw.split("\n")) {
+      if (!line) continue;
+      const idx = line.indexOf("|");
+      if (idx < 0) continue;
+      const tty = line.slice(0, idx);
+      const clientWindowId = line.slice(idx + 1);
+      if (clientWindowId === windowId) return tty || null;
     }
+    return null;
+  }
+
+  function isForegroundClient(ws: any): boolean {
+    const senderSession = clientSessionNames.get(ws) ?? null;
+    if (senderSession === "_os_stash") return false;
+
+    const senderWindowId = clientWindowIds.get(ws);
+    if (senderWindowId) {
+      const foregroundTty = getForegroundClientTtyForWindow(senderWindowId);
+      if (foregroundTty) return true;
+      return false;
+    }
+
+    const current = getCachedCurrentSession();
+    const currentTty = current ? clientTtyBySession.get(current) ?? null : null;
+    const senderTty = clientTtys.get(ws) ?? null;
+    if (currentTty && senderTty) return currentTty === senderTty;
+
+    if (senderSession && current) return senderSession === current;
+    return true;
+  }
+
+  function setFocus(name: string, sender?: any) {
+    if (!lastState || !lastState.sessions.some((s) => s.name === name)) return;
+
+    if (sender && !isForegroundClient(sender)) {
+      log("focus-session", "ignored from background sidebar", {
+        requested: name,
+        senderSession: clientSessionNames.get(sender) ?? null,
+        senderTty: clientTtys.get(sender) ?? null,
+        current: getCachedCurrentSession(),
+      });
+      return;
+    }
+
+    focusedSession = name;
+    broadcastFocusOnly(sender);
   }
 
   function handleFocus(name: string): void {
@@ -1396,10 +1446,25 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
         clientTtys.set(ws, cmd.clientTty);
         break;
       case "switch-session": {
-        // Resolve TTY: hook-derived (authoritative) > client-provided > stored
+        // Resolve TTY from the invoking WebSocket first.
+        // A restored/background sidebar can have a stale clientSessionNames entry,
+        // but its identify() handshake still carries the correct client TTY.
         const clientSess = clientSessionNames.get(ws);
-        const tty = (clientSess ? clientTtyBySession.get(clientSess) : undefined)
-          ?? cmd.clientTty ?? clientTtys.get(ws);
+        const senderWindowId = clientWindowIds.get(ws);
+        const foregroundTtyForWindow = getForegroundClientTtyForWindow(senderWindowId);
+        if (!isForegroundClient(ws)) {
+          log("switch-session", "ignored from background sidebar", {
+            target: cmd.name,
+            senderSession: clientSess ?? null,
+            senderTty: clientTtys.get(ws) ?? null,
+            current: getCachedCurrentSession(),
+          });
+          break;
+        }
+        const tty = foregroundTtyForWindow
+          ?? clientTtys.get(ws)
+          ?? cmd.clientTty
+          ?? (clientSess ? clientTtyBySession.get(clientSess) : undefined);
         log("switch-session", "switching", { target: cmd.name, tty, clientSess });
         const p = sessionProviders.get(cmd.name) ?? mux;
 
@@ -1457,8 +1522,18 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
       }
       case "switch-index": {
         const clientSess = clientSessionNames.get(ws);
-        const tty = (clientSess ? clientTtyBySession.get(clientSess) : undefined)
-          ?? clientTtys.get(ws);
+        if (!isForegroundClient(ws)) {
+          log("switch-index", "ignored from background sidebar", {
+            index: cmd.index,
+            senderSession: clientSess ?? null,
+            senderTty: clientTtys.get(ws) ?? null,
+            current: getCachedCurrentSession(),
+          });
+          break;
+        }
+        const tty = getForegroundClientTtyForWindow(clientWindowIds.get(ws))
+          ?? clientTtys.get(ws)
+          ?? (clientSess ? clientTtyBySession.get(clientSess) : undefined);
         switchToVisibleIndex(cmd.index, tty);
         break;
       }
@@ -1527,6 +1602,9 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
         break;
       case "identify-pane":
         if (cmd.windowId) clientWindowIds.set(ws, cmd.windowId);
+        // Hidden sidebar panes live in _os_stash temporarily; don't let that
+        // transient session overwrite the client's logical session identity.
+        if (cmd.sessionName === "_os_stash") break;
         // Store this client's session, reply with session + authoritative client TTY
         sendYourSession(ws, cmd.sessionName);
         break;
@@ -1547,14 +1625,17 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
         const session = clientSessionNames.get(ws) ?? null;
         const current = getCachedCurrentSession();
 
-        // Only the sidebar in the active session is allowed to author width
-        // changes. Background panes still receive resize events, but treating
+        // Only the foreground sidebar in the active session is allowed to
+        // author width changes. Background panes and temporarily stashed panes
+        // can emit resize events during scripted layout operations; treating
         // those as user intent causes global width ping-pong across sessions.
-        if (!session || !current || session !== current) {
-          log("report-width", "SKIP — not active session", {
+        if (!session || !current || session !== current || !isForegroundClient(ws)) {
+          log("report-width", "SKIP — not active foreground session", {
             reported,
             session,
             current,
+            senderTty: clientTtys.get(ws) ?? null,
+            senderWindowId: clientWindowIds.get(ws) ?? null,
             widthReportsSuppressed: areWidthReportsSuppressed(getSidebarState()),
           });
           break;
@@ -1701,6 +1782,16 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
       }
 
       // client-resized hook: terminal window changed size — enforce stored width
+      if (req.method === "POST" && url.pathname === "/suppress-width-reports") {
+        const msParam = Number.parseInt(url.searchParams.get("ms") ?? "", 10);
+        const ms = Number.isFinite(msParam) && msParam > 0
+          ? Math.min(msParam, 10_000)
+          : 2_000;
+        suppressWidthReports(ms);
+        log("http", "POST /suppress-width-reports", { ms });
+        return new Response("ok", { status: 200 });
+      }
+
       if (req.method === "POST" && url.pathname === "/client-resized") {
         log("http", "POST /client-resized", {
           sidebarVisible: isSidebarVisible(),

--- a/packages/runtime/test/even-horizontal-layout.test.ts
+++ b/packages/runtime/test/even-horizontal-layout.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+
+const helperPath = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "..",
+  "integrations",
+  "tmux-plugin",
+  "scripts",
+  "even-horizontal-common.sh",
+);
+
+function runHelper(body: string): string {
+  const result = Bun.spawnSync(
+    [
+      "sh",
+      "-lc",
+      `. '${helperPath}'
+${body}`,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.toString() || `shell failed with ${result.exitCode}`);
+  }
+
+  return result.stdout.toString().trim();
+}
+
+describe("even-horizontal shell helpers", () => {
+  const leftSidebarRows = [
+    "%1|opensessions-sidebar|30|0|29|0",
+    "%2|main-a|42|31|72|1",
+    "%3|main-b|42|74|115|0",
+    "%4|main-c|43|117|159|0",
+  ].join("\n");
+
+  const rightSidebarRows = [
+    "%2|main-a|43|0|42|1",
+    "%3|main-b|43|44|86|0",
+    "%4|main-c|43|88|130|0",
+    "%1|opensessions-sidebar|28|132|159|0",
+  ].join("\n");
+
+  test("counts sidebar vs non-sidebar panes", () => {
+    expect(runHelper(`count_sidebar_panes '${leftSidebarRows}'`)).toBe("1");
+    expect(runHelper(`count_non_sidebar_panes '${leftSidebarRows}'`)).toBe("3");
+  });
+
+  test("extracts sidebar pane metadata", () => {
+    expect(runHelper(`extract_sidebar_info '${leftSidebarRows}'`)).toBe("%1|30|0|29|0");
+  });
+
+  test("detects a left sidebar from pane geometry", () => {
+    expect(runHelper(`detect_sidebar_side '${leftSidebarRows}' '0' '29'`)).toBe("left");
+  });
+
+  test("detects a right sidebar from pane geometry", () => {
+    expect(runHelper(`detect_sidebar_side '${rightSidebarRows}' '132' '159'`)).toBe("right");
+  });
+
+  test("returns empty for ambiguous sidebar geometry", () => {
+    const ambiguousRows = [
+      "%1|opensessions-sidebar|40|20|59|0",
+      "%2|main-a|40|0|39|1",
+      "%3|main-b|40|61|100|0",
+    ].join("\n");
+
+    expect(runHelper(`detect_sidebar_side '${ambiguousRows}' '20' '59'`)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- add `prefix o → e` to spread non-sidebar panes in the current tmux window with `even-horizontal`
- preserve and restore the opensessions sidebar during relayout via shared tmux shell helpers
- harden sidebar focus and width synchronization so scripted relayouts do not poison stored sidebar width on session switch

## Changes
- add `integrations/tmux-plugin/scripts/even-horizontal.sh`
- add shared helpers in `integrations/tmux-plugin/scripts/even-horizontal-common.sh` and `integrations/tmux-plugin/scripts/sidebar-common.sh`
- bind `e` in `opensessions.tmux` and update uninstall/docs
- update TUI/session sync to re-identify on live pane session/window changes and only emit width reports for live active sessions
- update server-side width/focus handling to ignore `_os_stash`, gate width reports to the foreground sidebar client, and support temporary width-report suppression during scripted relayout
- add shell-helper tests in `packages/runtime/test/even-horizontal-layout.test.ts`

## Verification
- manually verified `prefix o → e` with left sidebar, right sidebar, and no sidebar
- manually reproduced the sidebar-width regression after relayout + session switch and verified it no longer jumps to the stash width
- ran `cd packages/runtime && bun test test/even-horizontal-layout.test.ts`
