### PR TITLE
feat(sessionizer): add SESSIONIZER_MAXDEPTH to configure search depth

### DIFF
--- a/apps/tui/scripts/sessionizer.sh
+++ b/apps/tui/scripts/sessionizer.sh
@@ -2,12 +2,18 @@
 # opensessions sessionizer — fuzzy directory picker for new tmux sessions
 # Requires: fzf, find
 # Supports colon-separated paths in SESSIONIZER_DIR (e.g. "$HOME/Code:$HOME/.config")
+# Search depth is configurable via SESSIONIZER_MAXDEPTH (default: 3)
 
 # Check env first, then tmux global environment, then default
 if [ -z "$SESSIONIZER_DIR" ] && command -v tmux &>/dev/null; then
   SESSIONIZER_DIR=$(tmux show-environment -g SESSIONIZER_DIR 2>/dev/null | sed 's/^SESSIONIZER_DIR=//')
 fi
 SEARCH_DIRS="${SESSIONIZER_DIR:-$HOME/Documents}"
+
+if [ -z "$SESSIONIZER_MAXDEPTH" ] && command -v tmux &>/dev/null; then
+  SESSIONIZER_MAXDEPTH=$(tmux show-environment -g SESSIONIZER_MAXDEPTH 2>/dev/null | sed 's/^SESSIONIZER_MAXDEPTH=//')
+fi
+MAXDEPTH="${SESSIONIZER_MAXDEPTH:-3}"
 
 if ! command -v fzf &>/dev/null; then
   echo "fzf is required for the sessionizer. Install it: https://github.com/junegunn/fzf"
@@ -26,7 +32,7 @@ if [ ${#valid_dirs[@]} -eq 0 ]; then
   exit 1
 fi
 
-selected=$(find "${valid_dirs[@]}" -mindepth 1 -maxdepth 3 -type d 2>/dev/null | fzf \
+selected=$(find "${valid_dirs[@]}" -mindepth 1 -maxdepth "$MAXDEPTH" -type d 2>/dev/null | fzf \
   --reverse \
   --header="Pick a directory for new session" \
   --preview=':' \

--- a/apps/tui/scripts/sessionizer.sh
+++ b/apps/tui/scripts/sessionizer.sh
@@ -14,6 +14,7 @@ if [ -z "$SESSIONIZER_MAXDEPTH" ] && command -v tmux &>/dev/null; then
   SESSIONIZER_MAXDEPTH=$(tmux show-environment -g SESSIONIZER_MAXDEPTH 2>/dev/null | sed 's/^SESSIONIZER_MAXDEPTH=//')
 fi
 MAXDEPTH="${SESSIONIZER_MAXDEPTH:-3}"
+[[ "$MAXDEPTH" =~ ^[1-9][0-9]*$ ]] || MAXDEPTH=3
 
 if ! command -v fzf &>/dev/null; then
   echo "fzf is required for the sessionizer. Install it: https://github.com/junegunn/fzf"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -137,6 +137,7 @@ All other tmux options fall back to the defaults shown in the table above.
 | `OPENSESSIONS_HOST` | helper shell scripts | Script-level override only; the app runtime still uses `127.0.0.1` |
 | `OPENSESSIONS_PORT` | helper shell scripts | Script-level override only; the app runtime still uses `7391` |
 | `SESSIONIZER_DIR` | tmux sessionizer popup | Colon-separated directories searched for new-session candidates (e.g. `$HOME/Code:$HOME/.config`). Also checked via `tmux show-environment -g` when the shell variable is unset. Defaults to `$HOME/Documents` |
+| `SESSIONIZER_MAXDEPTH` | tmux sessionizer popup | Maximum `find` depth when collecting new-session candidates. Set to `1` to list only top-level project directories. Also checked via `tmux show-environment -g` when the shell variable is unset. Defaults to `3` |
 | `BUN_PATH` | helper scripts | Explicit Bun binary path for helper scripts |
 
 ## Related Files Written By The Runtime

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -137,7 +137,7 @@ All other tmux options fall back to the defaults shown in the table above.
 | `OPENSESSIONS_HOST` | helper shell scripts | Script-level override only; the app runtime still uses `127.0.0.1` |
 | `OPENSESSIONS_PORT` | helper shell scripts | Script-level override only; the app runtime still uses `7391` |
 | `SESSIONIZER_DIR` | tmux sessionizer popup | Colon-separated directories searched for new-session candidates (e.g. `$HOME/Code:$HOME/.config`). Also checked via `tmux show-environment -g` when the shell variable is unset. Defaults to `$HOME/Documents` |
-| `SESSIONIZER_MAXDEPTH` | tmux sessionizer popup | Maximum `find` depth when collecting new-session candidates. Set to `1` to list only top-level project directories. Also checked via `tmux show-environment -g` when the shell variable is unset. Defaults to `3` |
+| `SESSIONIZER_MAXDEPTH` | tmux sessionizer popup | Maximum `find` depth when collecting new-session candidates. Also checked via `tmux show-environment -g` when the shell variable is unset. Defaults to `3` |
 | `BUN_PATH` | helper scripts | Explicit Bun binary path for helper scripts |
 
 ## Related Files Written By The Runtime

--- a/docs/reference/features-and-keybindings.md
+++ b/docs/reference/features-and-keybindings.md
@@ -87,6 +87,7 @@ Clicking a detected port opens `http://localhost:<port>`.
 - The server exposes `new-session` through the mux provider interface.
 - The TUI uses a tmux popup sessionizer when it is running inside tmux.
 - The bundled sessionizer searches directories listed in `SESSIONIZER_DIR` (colon-separated, e.g. `$HOME/Code:$HOME/.config`) or `$HOME/Documents` if unset. The variable is also read from the tmux global environment (`tmux set-environment -g`) as a fallback.
+- Search depth is controlled by `SESSIONIZER_MAXDEPTH` (defaults to `3`). Set it to `1` to restrict candidates to the top-level entries of each search root. The variable is also read from the tmux global environment as a fallback.
 - If `fzf` is unavailable, the tmux sessionizer exits with a prompt explaining that dependency.
 
 ## Session Switching Behavior

--- a/docs/reference/features-and-keybindings.md
+++ b/docs/reference/features-and-keybindings.md
@@ -87,7 +87,7 @@ Clicking a detected port opens `http://localhost:<port>`.
 - The server exposes `new-session` through the mux provider interface.
 - The TUI uses a tmux popup sessionizer when it is running inside tmux.
 - The bundled sessionizer searches directories listed in `SESSIONIZER_DIR` (colon-separated, e.g. `$HOME/Code:$HOME/.config`) or `$HOME/Documents` if unset. The variable is also read from the tmux global environment (`tmux set-environment -g`) as a fallback.
-- Search depth is controlled by `SESSIONIZER_MAXDEPTH` (defaults to `3`). Set it to `1` to restrict candidates to the top-level entries of each search root. The variable is also read from the tmux global environment as a fallback.
+- Search depth is controlled by `SESSIONIZER_MAXDEPTH` (defaults to `3`).
 - If `fzf` is unavailable, the tmux sessionizer exits with a prompt explaining that dependency.
 
 ## Session Switching Behavior


### PR DESCRIPTION
## Summary

- `SESSIONIZER_MAXDEPTH` (default `3`) now controls `find -maxdepth` in the sessionizer.
- Falls back to `tmux show-environment -g SESSIONIZER_MAXDEPTH` when the shell variable is unset, mirroring `SESSIONIZER_DIR` so it works from `display-popup` contexts.

## Motivation

`maxdepth 3` was hardcoded, which floods fzf with grandchildren for flat project layouts (e.g. `~/projects/foo`, `~/projects/bar`). Users can now set `1` for a top-level-only list, or raise it for deeply nested workspaces.