### PR TITLE
Dedupe Rust sidebars for tmux grouped sessions

### DIFF
--- a/apps/server-rs/src/lib.rs
+++ b/apps/server-rs/src/lib.rs
@@ -17,7 +17,7 @@ use opensessions_runtime::agent_watchers::{
 };
 use opensessions_runtime::git_info::{GitInfo, parse_git_info_output};
 use opensessions_runtime::metadata_store::SessionMetadataStore;
-use opensessions_runtime::mux::{MuxProvider, SidebarPosition};
+use opensessions_runtime::mux::{ActiveWindow, MuxProvider, SidebarPosition};
 use opensessions_runtime::pi_runtime_registry::{PiRuntimeRegistry, parse_pi_runtime_info};
 use opensessions_runtime::port_discovery::{PortDiscoveryInput, discover_session_ports};
 use opensessions_runtime::project_dir_session::{
@@ -88,11 +88,7 @@ fn debug_log(line: impl AsRef<str>) {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .unwrap_or(0);
-    if let Ok(mut file) = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-    {
+    if let Ok(mut file) = fs::OpenOptions::new().create(true).append(true).open(&path) {
         let _ = writeln!(file, "[{now}] [server] {}", line.as_ref());
     }
 }
@@ -596,10 +592,7 @@ impl StateSource for ReadOnlyMuxStateSource {
                     "report-width width={width} session={:?} window={:?} \
                      active_session={is_active_session} current_window={is_current_window} \
                      accepted={} reason={}",
-                    context.session_name,
-                    context.window_id,
-                    decision.accepted,
-                    decision.reason,
+                    context.session_name, context.window_id, decision.accepted, decision.reason,
                 ));
                 if !decision.accepted {
                     return None;
@@ -1165,7 +1158,26 @@ impl ReadOnlyMuxStateSource {
         self.sidebar_coordinator.lock().unwrap().begin_warmup();
         let width = (*self.sidebar_width.lock().unwrap()).min(u16::MAX as u32) as u16;
         for provider in providers {
+            let mut unique_windows = Vec::<ActiveWindow>::new();
             for window in provider.list_active_windows() {
+                if let Some(current) = unique_windows
+                    .iter_mut()
+                    .find(|current| current.id == window.id)
+                {
+                    if !current.active && window.active {
+                        *current = window;
+                    } else {
+                        debug_log(format!(
+                            "toggle_sidebar: skipping duplicate linked window session={} window={}",
+                            window.session_name, window.id,
+                        ));
+                    }
+                    continue;
+                }
+                unique_windows.push(window);
+            }
+
+            for window in unique_windows {
                 debug_log(format!(
                     "toggle_sidebar: spawning in session={} window={} width={width}",
                     window.session_name, window.id,

--- a/apps/server-rs/tests/protocol_shell.rs
+++ b/apps/server-rs/tests/protocol_shell.rs
@@ -1822,6 +1822,68 @@ async fn http_toggle_spawns_sidebar_in_active_windows_when_hidden() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn http_toggle_spawns_once_for_grouped_sessions_that_share_a_window() {
+    let pid_file = test_pid_file("http-toggle-grouped-session-spawn");
+    let mux = Arc::new(HookMux {
+        sidebar_panes: Vec::new(),
+        active_windows: vec![
+            ActiveWindow {
+                id: "@1".to_string(),
+                session_name: "p2".to_string(),
+                active: false,
+            },
+            ActiveWindow {
+                id: "@1".to_string(),
+                session_name: "p2-5".to_string(),
+                active: true,
+            },
+            ActiveWindow {
+                id: "@2".to_string(),
+                session_name: "pi".to_string(),
+                active: true,
+            },
+        ],
+        spawn_calls: Mutex::new(Vec::new()),
+        hide_calls: Mutex::new(Vec::new()),
+        orphan_cleanup_calls: Mutex::new(0),
+    });
+    let server = start_server(
+        ServerConfig::new("127.0.0.1", 0, &pid_file).with_state_source(
+            ReadOnlyMuxStateSource::new(vec![mux.clone()]).with_sidebar_width(31),
+        ),
+    )
+    .await
+    .expect("server should start");
+
+    let response = post_text(server.addr(), "/toggle", "/dev/ttys-test|p2-5|@1").await;
+    assert!(
+        response.starts_with("HTTP/1.1 200 OK\r\n"),
+        "response was {response}"
+    );
+    assert!(response.ends_with("\r\n\r\nok"));
+    assert_eq!(
+        *mux.spawn_calls.lock().unwrap(),
+        vec![
+            EnsureSpawnCall {
+                session_name: "p2-5".to_string(),
+                window_id: "@1".to_string(),
+                width: 31,
+                position: SidebarPosition::Left,
+            },
+            EnsureSpawnCall {
+                session_name: "pi".to_string(),
+                window_id: "@2".to_string(),
+                width: 31,
+                position: SidebarPosition::Left,
+            },
+        ]
+    );
+
+    server.shutdown().await.expect("server should shut down");
+    let _ = fs::remove_file(pid_file);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn http_agent_event_resolves_tmux_session_and_broadcasts_agent_state() {
     let pid_file = test_pid_file("http-agent-event");
     let mux = Arc::new(ServerMux {

--- a/packages/runtime-rs/src/tmux_provider.rs
+++ b/packages/runtime-rs/src/tmux_provider.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Command;
 use std::sync::Arc;
 
@@ -458,16 +458,28 @@ impl MuxProvider for TmuxProvider {
     }
 
     fn list_active_windows(&self) -> Vec<ActiveWindow> {
-        self.client
+        let mut windows = Vec::<ActiveWindow>::new();
+        for window in self
+            .client
             .list_windows()
             .into_iter()
             .filter(|window| window.session_name != STASH_SESSION)
-            .map(|window| ActiveWindow {
+        {
+            let next = ActiveWindow {
                 id: window.id,
                 session_name: window.session_name,
                 active: window.active,
-            })
-            .collect()
+            };
+            if let Some(current) = windows.iter_mut().find(|current| current.id == next.id) {
+                if !current.active && next.active {
+                    *current = next;
+                }
+            } else {
+                windows.push(next);
+            }
+        }
+
+        windows
     }
 
     fn get_current_window_id(&self) -> Option<String> {
@@ -488,11 +500,13 @@ impl MuxProvider for TmuxProvider {
                 .or_insert(width);
         }
 
+        let mut seen_pane_ids = HashSet::new();
         panes
             .into_iter()
             .filter(|pane| {
                 pane.title == "opensessions-sidebar" && pane.session_name != STASH_SESSION
             })
+            .filter(|pane| seen_pane_ids.insert(pane.id.clone()))
             .map(|pane| SidebarPane {
                 pane_id: pane.id,
                 session_name: pane.session_name,
@@ -591,9 +605,10 @@ impl MuxProvider for TmuxProvider {
         let panes = self.client.list_panes(PaneScope::All);
         let mut window_pane_counts: HashMap<String, u32> = HashMap::new();
         let mut sidebars_by_window: HashMap<String, Vec<String>> = HashMap::new();
+        let mut seen_pane_ids = HashSet::new();
 
         for pane in panes {
-            if pane.session_name == STASH_SESSION {
+            if pane.session_name == STASH_SESSION || !seen_pane_ids.insert(pane.id.clone()) {
                 continue;
             }
             *window_pane_counts

--- a/packages/runtime-rs/tests/tmux_provider.rs
+++ b/packages/runtime-rs/tests/tmux_provider.rs
@@ -114,7 +114,7 @@ fn tmux_provider_lists_active_windows_and_filters_stash_session() {
 fn tmux_provider_lists_sidebar_panes_with_window_widths() {
     let runner = RecordingRunner::new(HashMap::from([(
         "list-panes".to_string(),
-        "%1\talpha\t@1\t0\t0\t1\t/dev/ttys1\t123\t/repo\tbash\tmain\t94\t24\t26\t119\n%2\talpha\t@1\t0\t1\t0\t/dev/ttys2\t124\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%3\t_os_stash\t@2\t0\t0\t1\t/dev/ttys3\t125\t/tmp\tzsh\topensessions-sidebar\t26\t24\t0\t25"
+        "%1\talpha\t@1\t0\t0\t1\t/dev/ttys1\t123\t/repo\tbash\tmain\t94\t24\t26\t119\n%2\talpha\t@1\t0\t1\t0\t/dev/ttys2\t124\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%2\talpha-2\t@1\t0\t1\t0\t/dev/ttys2\t124\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%3\t_os_stash\t@2\t0\t0\t1\t/dev/ttys3\t125\t/tmp\tzsh\topensessions-sidebar\t26\t24\t0\t25"
             .to_string(),
     )]));
     let provider = TmuxProvider::new(Arc::new(runner));
@@ -126,6 +126,23 @@ fn tmux_provider_lists_sidebar_panes_with_window_widths() {
     assert_eq!(panes[0].window_id, "@1");
     assert_eq!(panes[0].width, Some(26));
     assert_eq!(panes[0].window_width, Some(120));
+}
+
+#[test]
+fn tmux_provider_deduplicates_grouped_session_windows_by_window_id() {
+    let runner = RecordingRunner::new(HashMap::from([(
+        "list-windows".to_string(),
+        "@1\t$1\talpha\t0\tmain\t0\t2\n@1\t$2\talpha-2\t0\tmain\t1\t2\n@2\t$1\talpha\t1\tworker\t0\t1"
+            .to_string(),
+    )]));
+    let provider = TmuxProvider::new(Arc::new(runner));
+
+    let windows = provider.list_active_windows();
+    assert_eq!(windows.len(), 2);
+    assert_eq!(windows[0].id, "@1");
+    assert_eq!(windows[0].session_name, "alpha-2");
+    assert!(windows[0].active);
+    assert_eq!(windows[1].id, "@2");
 }
 
 #[test]
@@ -231,7 +248,7 @@ fn tmux_provider_resolves_focuses_and_kills_agent_panes() {
 fn tmux_provider_kills_orphaned_and_duplicate_sidebar_panes() {
     let runner = Arc::new(RecordingRunner::new(HashMap::from([(
         "list-panes".to_string(),
-        "%1\talpha\t@1\t0\t0\t1\t/dev/ttys1\t123\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%2\tbeta\t@2\t0\t0\t1\t/dev/ttys2\t124\t/repo\tbash\tmain\t94\t24\t26\t119\n%3\tbeta\t@2\t0\t1\t0\t/dev/ttys3\t125\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%4\tbeta\t@2\t0\t2\t0\t/dev/ttys4\t126\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%5\t_os_stash\t@3\t0\t0\t1\t/dev/ttys5\t127\t/tmp\tzsh\topensessions-sidebar\t26\t24\t0\t25"
+        "%1\talpha\t@1\t0\t0\t1\t/dev/ttys1\t123\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%1\talpha-2\t@1\t0\t0\t1\t/dev/ttys1\t123\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%2\tbeta\t@2\t0\t0\t1\t/dev/ttys2\t124\t/repo\tbash\tmain\t94\t24\t26\t119\n%3\tbeta\t@2\t0\t1\t0\t/dev/ttys3\t125\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%4\tbeta\t@2\t0\t2\t0\t/dev/ttys4\t126\t/repo\tzsh\topensessions-sidebar\t26\t24\t0\t25\n%5\t_os_stash\t@3\t0\t0\t1\t/dev/ttys5\t127\t/tmp\tzsh\topensessions-sidebar\t26\t24\t0\t25"
             .to_string(),
     )])));
     let provider = TmuxProvider::new(runner.clone());


### PR DESCRIPTION
## Summary
- dedupe tmux active-window discovery by physical window id so grouped sessions do not spawn multiple Rust sidebars into the same shared window
- dedupe sidebar pane discovery/cleanup by physical pane id so linked-session listings do not look like duplicate panes
- add regression coverage for grouped-session toggle behavior

## Verification
- cargo test -p opensessions-runtime --test tmux_provider
- cargo test -p opensessions-server --test protocol_shell http_toggle -- --nocapture