### PR TITLE
fix(tmux): replace pane-exited with after-kill-pane; enforce width on pane close

### DIFF
--- a/packages/mux/providers/tmux/src/provider.ts
+++ b/packages/mux/providers/tmux/src/provider.ts
@@ -106,9 +106,10 @@ export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapabl
     tmux.setGlobalHook("after-new-window", ensureCmd);
     // client-resized: terminal window changed size — enforce stored width back
     tmux.setGlobalHook("client-resized", clientResizedCmd);
-    // pane-exited: a pane closed — kill orphaned sidebar panes (only pane left in window)
+    // after-kill-pane: a pane was killed — clean up orphaned sidebars and
+    // re-enforce width (pane-exited is not recognised by tmux 3.4+)
     const paneExitedCmd = hookPost("/pane-exited");
-    tmux.setGlobalHook("pane-exited", paneExitedCmd);
+    tmux.setGlobalHook("after-kill-pane", paneExitedCmd);
   }
 
   cleanupHooks(): void {
@@ -118,7 +119,7 @@ export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapabl
     tmux.unsetGlobalHook("after-select-window");
     tmux.unsetGlobalHook("after-new-window");
     tmux.unsetGlobalHook("client-resized");
-    tmux.unsetGlobalHook("pane-exited");
+    tmux.unsetGlobalHook("after-kill-pane");
   }
 
   getAllPaneCounts(): Map<string, number> {

--- a/packages/mux/tmux-sdk/src/index.ts
+++ b/packages/mux/tmux-sdk/src/index.ts
@@ -102,6 +102,7 @@ export const HOOK_NAMES = [
   "window-layout-changed",
   "after-select-window",
   "after-new-window",
+  "after-kill-pane",
   "after-resize-pane",
   "pane-died",
   "pane-exited",

--- a/packages/runtime/src/server/index.ts
+++ b/packages/runtime/src/server/index.ts
@@ -2285,13 +2285,15 @@ export function startServer(mux: MuxProvider, extraProviders?: MuxProvider[], wa
         return new Response("ok", { status: 200 });
       }
 
-      // pane-exited hook: a pane closed — kill orphaned sidebar panes
+      // pane-exited hook: a pane closed — kill orphaned sidebar panes and
+      // re-enforce sidebar width (tmux redistributes space when panes close)
       if (req.method === "POST" && url.pathname === "/pane-exited") {
         if (isSidebarVisible()) {
           invalidateSidebarPaneCache();
           for (const { provider } of listSidebarPanesByProvider()) {
             provider.killOrphanedSidebarPanes();
           }
+          scheduleClientResizeSync();
         }
         return new Response("ok", { status: 200 });
       }


### PR DESCRIPTION
## Problem

Two features that were supposed to work after a pane is closed have never actually fired on tmux 3.4+:

1. **Orphaned sidebar cleanup** — when all content panes in a window are closed, the sidebar pane is supposed to be killed automatically.
2. **Sidebar width enforcement** — when a pane is closed, tmux redistributes window space and can resize the sidebar away from its configured width. The server was supposed to snap it back.

Both are broken because they relied on the `pane-exited` hook, which is silently ignored by tmux 3.4+. `set-hook -g pane-exited ...` returns exit code 0 but the hook never appears in `show-hooks` and never fires.

## Fix

**`packages/mux/providers/tmux/src/provider.ts`**
Replace `pane-exited` with `after-kill-pane`, which fires reliably after every `kill-pane` command on modern tmux. Also update `cleanupHooks()` to unset the correct hook name on shutdown.

**`packages/mux/tmux-sdk/src/index.ts`**
Add `after-kill-pane` to `HOOK_NAMES` so the type is correct.

**`packages/runtime/src/server/index.ts`**
Add `scheduleClientResizeSync()` to the `/pane-exited` handler so sidebar width is enforced after a pane close, not just on terminal resize.

## Verified on

- tmux 3.6a / macOS — `after-kill-pane` appears in `show-hooks` and fires correctly
- [x] Closing all content panes in a window kills the orphaned sidebar automatically
- [x] Sidebar width is restored after closing a pane (no longer drifts)
- [x] `pane-exited` no longer appears in `show-hooks` (was silently registered before this fix)

## Test plan

- [x] Open a window with sidebar + 2 content panes; close one pane; verify sidebar width stays at configured value
- [x] Close all content panes; verify sidebar pane is killed automatically (window closes)
- [x] Confirm `after-kill-pane` appears in `tmux show-hooks -g` after starting the server
- [x] Confirm `pane-exited` no longer appears