### PR TITLE
fix: finish Rust port-base migration (17000 → 22000) across remaining call sites

### DIFF
--- a/apps/tui-rs/src/runtime_config.rs
+++ b/apps/tui-rs/src/runtime_config.rs
@@ -1,4 +1,8 @@
 pub const DEFAULT_SERVER_PORT: u16 = 7_391;
+// SERVER_PORT_BASE is duplicated here for the TUI sidebar binary (which does
+// not depend on packages/runtime-rs). The canonical definition lives in
+// packages/runtime-rs/src/shared.rs and must be kept in sync — both values
+// describe the same port range the server binds.
 pub const SERVER_PORT_BASE: u32 = 22_000;
 
 pub fn hash_server_key(input: &str) -> u16 {
@@ -18,8 +22,13 @@ pub fn resolve_server_port(server_key: Option<u16>, explicit: Option<&str>) -> u
     }
 
     match server_key {
-        Some(key) => u16::try_from(SERVER_PORT_BASE + u32::from(key))
-            .unwrap_or(DEFAULT_SERVER_PORT),
+        Some(key) => u16::try_from(SERVER_PORT_BASE + u32::from(key)).unwrap_or_else(|_| {
+            eprintln!(
+                "opensessions: server_key {key} + base {SERVER_PORT_BASE} overflows port range, \
+                 falling back to DEFAULT_SERVER_PORT {DEFAULT_SERVER_PORT}",
+            );
+            DEFAULT_SERVER_PORT
+        }),
         None => DEFAULT_SERVER_PORT,
     }
 }

--- a/apps/tui-rs/src/runtime_config.rs
+++ b/apps/tui-rs/src/runtime_config.rs
@@ -18,7 +18,8 @@ pub fn resolve_server_port(server_key: Option<u16>, explicit: Option<&str>) -> u
     }
 
     match server_key {
-        Some(key) => (SERVER_PORT_BASE + u32::from(key)) as u16,
+        Some(key) => u16::try_from(SERVER_PORT_BASE + u32::from(key))
+            .unwrap_or(DEFAULT_SERVER_PORT),
         None => DEFAULT_SERVER_PORT,
     }
 }

--- a/apps/tui-rs/src/runtime_config.rs
+++ b/apps/tui-rs/src/runtime_config.rs
@@ -17,7 +17,7 @@ pub fn resolve_server_port(server_key: Option<u16>, explicit: Option<&str>) -> u
     }
 
     match server_key {
-        Some(key) => 17_000 + key,
+        Some(key) => 22_000 + key,
         None => DEFAULT_SERVER_PORT,
     }
 }

--- a/apps/tui-rs/src/runtime_config.rs
+++ b/apps/tui-rs/src/runtime_config.rs
@@ -1,4 +1,5 @@
 pub const DEFAULT_SERVER_PORT: u16 = 7_391;
+pub const SERVER_PORT_BASE: u32 = 22_000;
 
 pub fn hash_server_key(input: &str) -> u16 {
     let mut hash = 0_u32;
@@ -17,7 +18,7 @@ pub fn resolve_server_port(server_key: Option<u16>, explicit: Option<&str>) -> u
     }
 
     match server_key {
-        Some(key) => 22_000 + key,
+        Some(key) => (SERVER_PORT_BASE + u32::from(key)) as u16,
         None => DEFAULT_SERVER_PORT,
     }
 }

--- a/apps/tui-rs/tests/cli.rs
+++ b/apps/tui-rs/tests/cli.rs
@@ -29,7 +29,7 @@ fn resolves_tmux_derived_endpoint_from_environment_like_typescript_client() {
     });
 
     assert_eq!(endpoint.server_host, "127.0.0.1");
-    assert_eq!(endpoint.server_port, 36_916);
+    assert_eq!(endpoint.server_port, 41_916);
 }
 
 #[test]

--- a/apps/tui-rs/tests/protocol.rs
+++ b/apps/tui-rs/tests/protocol.rs
@@ -78,4 +78,8 @@ fn server_key_hash_matches_typescript_runtime() {
     assert_eq!(resolve_server_port(None, None), 7_391);
     assert_eq!(resolve_server_port(Some(19_916), None), 41_916);
     assert_eq!(resolve_server_port(Some(19_916), Some("8123")), 8_123);
+    // Overflow fallback: any key that pushes 22000+key above u16::MAX
+    // must fall back to DEFAULT_SERVER_PORT rather than silently wrap.
+    assert_eq!(resolve_server_port(Some(50_000), None), 7_391);
+    assert_eq!(resolve_server_port(Some(u16::MAX), None), 7_391);
 }

--- a/apps/tui-rs/tests/protocol.rs
+++ b/apps/tui-rs/tests/protocol.rs
@@ -76,6 +76,6 @@ fn parses_state_with_nested_agent_and_filter() {
 fn server_key_hash_matches_typescript_runtime() {
     assert_eq!(hash_server_key("/private/tmp/tmux-501/default"), 19_916);
     assert_eq!(resolve_server_port(None, None), 7_391);
-    assert_eq!(resolve_server_port(Some(19_916), None), 36_916);
+    assert_eq!(resolve_server_port(Some(19_916), None), 41_916);
     assert_eq!(resolve_server_port(Some(19_916), Some("8123")), 8_123);
 }

--- a/docs/ratatui-migration/04-protocol-and-types.md
+++ b/docs/ratatui-migration/04-protocol-and-types.md
@@ -9,7 +9,7 @@ source); use `#[serde(rename_all = "camelCase")]` on every struct.
 
 - URL: `ws://{SERVER_HOST}:{SERVER_PORT}/`  (no path used today)
 - Default `SERVER_HOST = 127.0.0.1`, port resolved from `OPENSESSIONS_PORT`
-  env or hashed from `$TMUX` socket path → `17000 + (hash % 20000)`.
+  env or hashed from `$TMUX` socket path → `22000 + (hash % 20000)`.
 - Single connection per pane. Auto-reconnect on close.
 - Text frames only (JSON). No binary.
 

--- a/docs/ratatui-migration/11-config-and-persistence.md
+++ b/docs/ratatui-migration/11-config-and-persistence.md
@@ -193,7 +193,7 @@ fn server_port() -> u16 {
     }
     let key = server_key();
     match key {
-        Some(k) => 17000 + k,
+        Some(k) => 22000 + k,
         None => 7391,  // DEFAULT_SERVER_PORT
     }
 }

--- a/integrations/amp/opensessions.ts
+++ b/integrations/amp/opensessions.ts
@@ -128,7 +128,9 @@ function hashServerKey(input: string): number {
 // lenient ("123abc" -> 123, "0.5" -> 0) and `Number()` is too permissive
 // ("1.0", "1e3", "0x10" all coerce to integers); both diverge from Rust,
 // which would Err on those inputs and fall back to DEFAULT_SERVER_PORT.
-const DECIMAL_INTEGER_RE = /^[0-9]+$/;
+// The optional leading `+` mirrors Rust's `u16::from_str` / `u32::from_str`
+// (verified: `"+8123".parse::<u16>()` => Ok(8123) on rustc 1.96).
+const DECIMAL_INTEGER_RE = /^\+?[0-9]+$/;
 
 function resolveServerPort(): number {
   const explicitPort = process.env.OPENSESSIONS_PORT?.trim();

--- a/integrations/amp/opensessions.ts
+++ b/integrations/amp/opensessions.ts
@@ -128,7 +128,13 @@ function resolveServerPort(): number {
   if (Number.isFinite(explicit) && explicit > 0) return explicit;
 
   const explicitKey = process.env.OPENSESSIONS_SERVER_KEY?.trim();
-  if (explicitKey) return 22000 + Number.parseInt(explicitKey, 10);
+  if (explicitKey) {
+    const key = Number.parseInt(explicitKey, 10);
+    if (Number.isFinite(key) && key >= 0) {
+      const port = 22000 + key;
+      if (port > 0 && port <= 65535) return port;
+    }
+  }
 
   const tmux = process.env.TMUX?.trim();
   if (tmux) {

--- a/integrations/amp/opensessions.ts
+++ b/integrations/amp/opensessions.ts
@@ -134,6 +134,12 @@ function resolveServerPort(): number {
       const port = 22000 + key;
       if (port > 0 && port <= 65535) return port;
     }
+    // Mirror packages/runtime-rs/src/shared.rs: an explicit-but-invalid
+    // OPENSESSIONS_SERVER_KEY must fall back to DEFAULT_SERVER_PORT, not
+    // to the TMUX-derived port. Otherwise client and Rust server would
+    // talk to different ports (server sees the same bad env var and
+    // returns DEFAULT_SERVER_PORT, client would derive a TMUX hash port).
+    return DEFAULT_SERVER_PORT;
   }
 
   const tmux = process.env.TMUX?.trim();

--- a/integrations/amp/opensessions.ts
+++ b/integrations/amp/opensessions.ts
@@ -129,16 +129,18 @@ function resolveServerPort(): number {
 
   const explicitKey = process.env.OPENSESSIONS_SERVER_KEY?.trim();
   if (explicitKey) {
-    const key = Number.parseInt(explicitKey, 10);
-    if (Number.isFinite(key) && key >= 0) {
+    // Use Number() + Number.isInteger to match the strictness of Rust's
+    // `parse::<u32>()` in packages/runtime-rs/src/shared.rs. `Number.parseInt`
+    // is too lenient ("123abc" -> 123, "0.5" -> 0) and would diverge from
+    // the Rust server, which Err's on those inputs and falls back to
+    // DEFAULT_SERVER_PORT.
+    const key = Number(explicitKey);
+    if (Number.isInteger(key) && key >= 0) {
       const port = 22000 + key;
       if (port > 0 && port <= 65535) return port;
     }
-    // Mirror packages/runtime-rs/src/shared.rs: an explicit-but-invalid
-    // OPENSESSIONS_SERVER_KEY must fall back to DEFAULT_SERVER_PORT, not
-    // to the TMUX-derived port. Otherwise client and Rust server would
-    // talk to different ports (server sees the same bad env var and
-    // returns DEFAULT_SERVER_PORT, client would derive a TMUX hash port).
+    // Any explicit-but-invalid OPENSESSIONS_SERVER_KEY falls back to the
+    // default port (matching the Rust server) so client and server agree.
     return DEFAULT_SERVER_PORT;
   }
 

--- a/integrations/amp/opensessions.ts
+++ b/integrations/amp/opensessions.ts
@@ -128,12 +128,12 @@ function resolveServerPort(): number {
   if (Number.isFinite(explicit) && explicit > 0) return explicit;
 
   const explicitKey = process.env.OPENSESSIONS_SERVER_KEY?.trim();
-  if (explicitKey) return 17000 + Number.parseInt(explicitKey, 10);
+  if (explicitKey) return 22000 + Number.parseInt(explicitKey, 10);
 
   const tmux = process.env.TMUX?.trim();
   if (tmux) {
     const socketPath = tmux.split(",", 1)[0];
-    if (socketPath) return 17000 + hashServerKey(socketPath);
+    if (socketPath) return 22000 + hashServerKey(socketPath);
   }
   return DEFAULT_SERVER_PORT;
 }

--- a/integrations/amp/opensessions.ts
+++ b/integrations/amp/opensessions.ts
@@ -123,21 +123,28 @@ function hashServerKey(input: string): number {
   return hash;
 }
 
+// Mirror Rust's strict integer parse (`parse::<u32>()` / `parse::<u16>()` in
+// packages/runtime-rs/src/shared.rs). JavaScript's `Number.parseInt` is
+// lenient ("123abc" -> 123, "0.5" -> 0) and `Number()` is too permissive
+// ("1.0", "1e3", "0x10" all coerce to integers); both diverge from Rust,
+// which would Err on those inputs and fall back to DEFAULT_SERVER_PORT.
+const DECIMAL_INTEGER_RE = /^[0-9]+$/;
+
 function resolveServerPort(): number {
-  const explicit = Number.parseInt(process.env.OPENSESSIONS_PORT ?? "", 10);
-  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const explicitPort = process.env.OPENSESSIONS_PORT?.trim();
+  if (explicitPort && DECIMAL_INTEGER_RE.test(explicitPort)) {
+    const port = Number(explicitPort);
+    if (Number.isInteger(port) && port > 0 && port <= 65535) return port;
+  }
 
   const explicitKey = process.env.OPENSESSIONS_SERVER_KEY?.trim();
   if (explicitKey) {
-    // Use Number() + Number.isInteger to match the strictness of Rust's
-    // `parse::<u32>()` in packages/runtime-rs/src/shared.rs. `Number.parseInt`
-    // is too lenient ("123abc" -> 123, "0.5" -> 0) and would diverge from
-    // the Rust server, which Err's on those inputs and falls back to
-    // DEFAULT_SERVER_PORT.
-    const key = Number(explicitKey);
-    if (Number.isInteger(key) && key >= 0) {
-      const port = 22000 + key;
-      if (port > 0 && port <= 65535) return port;
+    if (DECIMAL_INTEGER_RE.test(explicitKey)) {
+      const key = Number(explicitKey);
+      if (Number.isInteger(key) && key >= 0) {
+        const port = 22000 + key;
+        if (port > 0 && port <= 65535) return port;
+      }
     }
     // Any explicit-but-invalid OPENSESSIONS_SERVER_KEY falls back to the
     // default port (matching the Rust server) so client and server agree.

--- a/integrations/pi-extension/opensessions-runtime.ts
+++ b/integrations/pi-extension/opensessions-runtime.ts
@@ -31,12 +31,12 @@ function resolveServerPort(): number {
   if (Number.isFinite(explicit) && explicit > 0) return explicit;
 
   const explicitKey = process.env.OPENSESSIONS_SERVER_KEY?.trim();
-  if (explicitKey) return 17000 + Number.parseInt(explicitKey, 10);
+  if (explicitKey) return 22000 + Number.parseInt(explicitKey, 10);
 
   const tmux = process.env.TMUX?.trim();
   if (tmux) {
     const socketPath = tmux.split(",", 1)[0];
-    if (socketPath) return 17000 + hashServerKey(socketPath);
+    if (socketPath) return 22000 + hashServerKey(socketPath);
   }
   return DEFAULT_SERVER_PORT;
 }

--- a/integrations/pi-extension/opensessions-runtime.ts
+++ b/integrations/pi-extension/opensessions-runtime.ts
@@ -31,7 +31,9 @@ function hashServerKey(input: string): number {
 // `Number()` both accept formats Rust rejects ("123abc", "0.5", "1e3",
 // "0x10"); the heartbeat client must Err on the same inputs or it will
 // post to a different port than the server binds.
-const DECIMAL_INTEGER_RE = /^[0-9]+$/;
+// The optional leading `+` mirrors Rust's `u16::from_str` / `u32::from_str`
+// (verified: `"+8123".parse::<u16>()` => Ok(8123) on rustc 1.96).
+const DECIMAL_INTEGER_RE = /^\+?[0-9]+$/;
 
 function resolveServerPort(): number {
   const explicitPort = process.env.OPENSESSIONS_PORT?.trim();

--- a/integrations/pi-extension/opensessions-runtime.ts
+++ b/integrations/pi-extension/opensessions-runtime.ts
@@ -31,7 +31,13 @@ function resolveServerPort(): number {
   if (Number.isFinite(explicit) && explicit > 0) return explicit;
 
   const explicitKey = process.env.OPENSESSIONS_SERVER_KEY?.trim();
-  if (explicitKey) return 22000 + Number.parseInt(explicitKey, 10);
+  if (explicitKey) {
+    const key = Number.parseInt(explicitKey, 10);
+    if (Number.isFinite(key) && key >= 0) {
+      const port = 22000 + key;
+      if (port > 0 && port <= 65535) return port;
+    }
+  }
 
   const tmux = process.env.TMUX?.trim();
   if (tmux) {

--- a/integrations/pi-extension/opensessions-runtime.ts
+++ b/integrations/pi-extension/opensessions-runtime.ts
@@ -37,6 +37,11 @@ function resolveServerPort(): number {
       const port = 22000 + key;
       if (port > 0 && port <= 65535) return port;
     }
+    // Mirror packages/runtime-rs/src/shared.rs: an explicit-but-invalid
+    // OPENSESSIONS_SERVER_KEY must fall back to DEFAULT_SERVER_PORT, not
+    // to the TMUX-derived port. Otherwise the heartbeat client and Rust
+    // server would resolve to different ports.
+    return DEFAULT_SERVER_PORT;
   }
 
   const tmux = process.env.TMUX?.trim();

--- a/integrations/pi-extension/opensessions-runtime.ts
+++ b/integrations/pi-extension/opensessions-runtime.ts
@@ -26,19 +26,28 @@ function hashServerKey(input: string): number {
   return hash;
 }
 
+// Mirror Rust's strict integer parse (`parse::<u32>()` / `parse::<u16>()` in
+// packages/runtime-rs/src/shared.rs). JavaScript's `Number.parseInt` and
+// `Number()` both accept formats Rust rejects ("123abc", "0.5", "1e3",
+// "0x10"); the heartbeat client must Err on the same inputs or it will
+// post to a different port than the server binds.
+const DECIMAL_INTEGER_RE = /^[0-9]+$/;
+
 function resolveServerPort(): number {
-  const explicit = Number.parseInt(process.env.OPENSESSIONS_PORT ?? "", 10);
-  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const explicitPort = process.env.OPENSESSIONS_PORT?.trim();
+  if (explicitPort && DECIMAL_INTEGER_RE.test(explicitPort)) {
+    const port = Number(explicitPort);
+    if (Number.isInteger(port) && port > 0 && port <= 65535) return port;
+  }
 
   const explicitKey = process.env.OPENSESSIONS_SERVER_KEY?.trim();
   if (explicitKey) {
-    // Use Number() + Number.isInteger to match Rust's strict `parse::<u32>()`
-    // in packages/runtime-rs/src/shared.rs. `Number.parseInt` is too lenient
-    // ("123abc" -> 123, "0.5" -> 0) and would diverge from the Rust server.
-    const key = Number(explicitKey);
-    if (Number.isInteger(key) && key >= 0) {
-      const port = 22000 + key;
-      if (port > 0 && port <= 65535) return port;
+    if (DECIMAL_INTEGER_RE.test(explicitKey)) {
+      const key = Number(explicitKey);
+      if (Number.isInteger(key) && key >= 0) {
+        const port = 22000 + key;
+        if (port > 0 && port <= 65535) return port;
+      }
     }
     // Any explicit-but-invalid OPENSESSIONS_SERVER_KEY falls back to the
     // default port (matching the Rust server) so heartbeat client and

--- a/integrations/pi-extension/opensessions-runtime.ts
+++ b/integrations/pi-extension/opensessions-runtime.ts
@@ -32,15 +32,17 @@ function resolveServerPort(): number {
 
   const explicitKey = process.env.OPENSESSIONS_SERVER_KEY?.trim();
   if (explicitKey) {
-    const key = Number.parseInt(explicitKey, 10);
-    if (Number.isFinite(key) && key >= 0) {
+    // Use Number() + Number.isInteger to match Rust's strict `parse::<u32>()`
+    // in packages/runtime-rs/src/shared.rs. `Number.parseInt` is too lenient
+    // ("123abc" -> 123, "0.5" -> 0) and would diverge from the Rust server.
+    const key = Number(explicitKey);
+    if (Number.isInteger(key) && key >= 0) {
       const port = 22000 + key;
       if (port > 0 && port <= 65535) return port;
     }
-    // Mirror packages/runtime-rs/src/shared.rs: an explicit-but-invalid
-    // OPENSESSIONS_SERVER_KEY must fall back to DEFAULT_SERVER_PORT, not
-    // to the TMUX-derived port. Otherwise the heartbeat client and Rust
-    // server would resolve to different ports.
+    // Any explicit-but-invalid OPENSESSIONS_SERVER_KEY falls back to the
+    // default port (matching the Rust server) so heartbeat client and
+    // server agree.
     return DEFAULT_SERVER_PORT;
   }
 

--- a/packages/runtime-rs/src/shared.rs
+++ b/packages/runtime-rs/src/shared.rs
@@ -1,5 +1,8 @@
 pub const DEFAULT_SERVER_PORT: u16 = 7_391;
 pub const DEFAULT_SERVER_HOST: &str = "127.0.0.1";
+// SERVER_PORT_BASE is canonically defined here. apps/tui-rs/src/runtime_config.rs
+// keeps a duplicate copy because the TUI sidebar binary does not depend on this
+// crate; both values must stay in sync.
 pub const SERVER_PORT_BASE: u32 = 22_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,9 +43,10 @@ pub fn resolve_server_port(server_key: Option<&str>, explicit: Option<&str>) -> 
 }
 
 /// Compute the port like [`resolve_server_port`] but with a configurable base.
-/// `base + server_key` is computed in `u32` and then cast to `u16`; callers must
-/// ensure `base + server_key <= u16::MAX`. Mirrors `PORT_BASE` in
-/// `integrations/tmux-plugin/scripts/server-common.sh`.
+/// `base + server_key` is computed in `u32`; if the sum overflows `u32` or
+/// exceeds `u16::MAX`, falls back to `DEFAULT_SERVER_PORT` (matching the
+/// parse-failure branch) and emits an `opensessions: ...` warning to stderr.
+/// Mirrors `PORT_BASE` in `integrations/tmux-plugin/scripts/server-common.sh`.
 pub fn resolve_server_port_with_base(
     server_key: Option<&str>,
     explicit: Option<&str>,
@@ -63,7 +67,13 @@ pub fn resolve_server_port_with_base(
         Ok(key) => base
             .checked_add(key)
             .and_then(|sum| u16::try_from(sum).ok())
-            .unwrap_or(DEFAULT_SERVER_PORT),
+            .unwrap_or_else(|| {
+                eprintln!(
+                    "opensessions: server_key {key} + base {base} overflows port range, \
+                     falling back to DEFAULT_SERVER_PORT {DEFAULT_SERVER_PORT}",
+                );
+                DEFAULT_SERVER_PORT
+            }),
         Err(_) => DEFAULT_SERVER_PORT,
     }
 }

--- a/packages/runtime-rs/src/shared.rs
+++ b/packages/runtime-rs/src/shared.rs
@@ -1,5 +1,6 @@
 pub const DEFAULT_SERVER_PORT: u16 = 7_391;
 pub const DEFAULT_SERVER_HOST: &str = "127.0.0.1";
+pub const SERVER_PORT_BASE: u32 = 22_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerSettings {
@@ -35,14 +36,13 @@ pub fn resolve_server_key(env: impl Fn(&str) -> Option<String>) -> Option<String
 }
 
 pub fn resolve_server_port(server_key: Option<&str>, explicit: Option<&str>) -> u16 {
-    resolve_server_port_with_base(server_key, explicit, 22_000)
+    resolve_server_port_with_base(server_key, explicit, SERVER_PORT_BASE)
 }
 
 /// Compute the port like [`resolve_server_port`] but with a configurable base.
-/// Mirrors the `PORT_BASE` branch in
-/// `integrations/tmux-plugin/scripts/server-common.sh` so the Rust server can
-/// pin 22000+server_key when `OPENSESSIONS_RUST=1` and coexist with the TS
-/// bun server (17000+server_key) on the same tmux socket.
+/// `base + server_key` is computed in `u32` and then cast to `u16`; callers must
+/// ensure `base + server_key <= u16::MAX`. Mirrors `PORT_BASE` in
+/// `integrations/tmux-plugin/scripts/server-common.sh`.
 pub fn resolve_server_port_with_base(
     server_key: Option<&str>,
     explicit: Option<&str>,
@@ -90,7 +90,7 @@ pub fn resolve_server_settings(env: impl Fn(&str) -> Option<String>) -> ServerSe
     let port = resolve_server_port_with_base(
         server_key.as_deref(),
         env("OPENSESSIONS_PORT").as_deref(),
-        22_000,
+        SERVER_PORT_BASE,
     );
     let pid_file = resolve_pid_file(
         server_key.as_deref(),

--- a/packages/runtime-rs/src/shared.rs
+++ b/packages/runtime-rs/src/shared.rs
@@ -60,7 +60,10 @@ pub fn resolve_server_port_with_base(
     };
 
     match server_key.trim().parse::<u32>() {
-        Ok(key) => (base + key) as u16,
+        Ok(key) => base
+            .checked_add(key)
+            .and_then(|sum| u16::try_from(sum).ok())
+            .unwrap_or(DEFAULT_SERVER_PORT),
         Err(_) => DEFAULT_SERVER_PORT,
     }
 }

--- a/packages/runtime-rs/src/shared.rs
+++ b/packages/runtime-rs/src/shared.rs
@@ -35,7 +35,7 @@ pub fn resolve_server_key(env: impl Fn(&str) -> Option<String>) -> Option<String
 }
 
 pub fn resolve_server_port(server_key: Option<&str>, explicit: Option<&str>) -> u16 {
-    resolve_server_port_with_base(server_key, explicit, 17_000)
+    resolve_server_port_with_base(server_key, explicit, 22_000)
 }
 
 /// Compute the port like [`resolve_server_port`] but with a configurable base.
@@ -87,18 +87,10 @@ pub fn resolve_pid_file(server_key: Option<&str>, explicit: Option<&str>) -> Str
 pub fn resolve_server_settings(env: impl Fn(&str) -> Option<String>) -> ServerSettings {
     let server_key = resolve_server_key(&env);
     let host = resolve_server_host(env("OPENSESSIONS_HOST").as_deref());
-    let base = if env("OPENSESSIONS_RUST")
-        .map(|value| value.trim() == "1")
-        .unwrap_or(false)
-    {
-        22_000
-    } else {
-        17_000
-    };
     let port = resolve_server_port_with_base(
         server_key.as_deref(),
         env("OPENSESSIONS_PORT").as_deref(),
-        base,
+        22_000,
     );
     let pid_file = resolve_pid_file(
         server_key.as_deref(),

--- a/packages/runtime-rs/tests/config_and_shared.rs
+++ b/packages/runtime-rs/tests/config_and_shared.rs
@@ -46,35 +46,33 @@ fn resolve_server_settings_ignores_opensessions_rust_env_var() {
     // (17000+server_key) coexisted with the Rust stack. The TS server is
     // gone (commit 89168a3) and the Rust stack now always binds
     // 22000+server_key (`SERVER_PORT_BASE`) regardless of this env var.
-    let settings = resolve_server_settings(|key| match key {
-        "TMUX" => Some("/private/tmp/tmux-501/os-rs-test,123,0".to_string()),
+    let tmux = "/private/tmp/tmux-501/os-rs-test,123,0";
+    let with_env_set = resolve_server_settings(|key| match key {
+        "TMUX" => Some(tmux.to_string()),
         "OPENSESSIONS_RUST" => Some("1".to_string()),
         _ => None,
     });
-
-    assert_eq!(settings.server_key.as_deref(), Some("8011"));
-    assert_eq!(
-        settings.port, 30_011,
-        "Rust stack must bind base 22000 (got {})",
-        settings.port
-    );
-}
-
-#[test]
-fn resolve_server_settings_uses_default_port_base_without_opensessions_rust() {
-    let settings = resolve_server_settings(|key| match key {
-        "TMUX" => Some("/private/tmp/tmux-501/os-rs-test,123,0".to_string()),
+    let with_env_unset = resolve_server_settings(|key| match key {
+        "TMUX" => Some(tmux.to_string()),
         _ => None,
     });
 
-    assert_eq!(settings.port, 30_011);
+    assert_eq!(with_env_set.server_key.as_deref(), Some("8011"));
+    assert_eq!(
+        with_env_set.port, 30_011,
+        "Rust stack must bind base 22000 (got {})",
+        with_env_set.port
+    );
+    assert_eq!(
+        with_env_unset.port, with_env_set.port,
+        "OPENSESSIONS_RUST must have no effect on port resolution"
+    );
 }
 
 #[test]
 fn resolve_server_settings_explicit_port_overrides_port_base() {
     let settings = resolve_server_settings(|key| match key {
         "TMUX" => Some("/private/tmp/tmux-501/os-rs-test,123,0".to_string()),
-        "OPENSESSIONS_RUST" => Some("1".to_string()),
         "OPENSESSIONS_PORT" => Some("42424".to_string()),
         _ => None,
     });

--- a/packages/runtime-rs/tests/config_and_shared.rs
+++ b/packages/runtime-rs/tests/config_and_shared.rs
@@ -33,12 +33,11 @@ fn resolves_server_settings_from_tmux_socket_and_env_overrides() {
 }
 
 #[test]
-fn resolve_server_settings_uses_rust_port_base_when_opensessions_rust_set() {
+fn resolve_server_settings_ignores_opensessions_rust_env_var() {
     // OPENSESSIONS_RUST=1 was an opt-in toggle while the TS bun server
     // (17000+server_key) coexisted with the Rust stack. The TS server is
     // gone (commit 89168a3) and the Rust stack now always binds
-    // 22000+server_key (`SERVER_PORT_BASE`). The env var is still accepted
-    // for backwards-compatibility but no longer affects the port.
+    // 22000+server_key (`SERVER_PORT_BASE`) regardless of this env var.
     let settings = resolve_server_settings(|key| match key {
         "TMUX" => Some("/private/tmp/tmux-501/os-rs-test,123,0".to_string()),
         "OPENSESSIONS_RUST" => Some("1".to_string()),
@@ -48,13 +47,13 @@ fn resolve_server_settings_uses_rust_port_base_when_opensessions_rust_set() {
     assert_eq!(settings.server_key.as_deref(), Some("8011"));
     assert_eq!(
         settings.port, 30_011,
-        "OPENSESSIONS_RUST=1 must use base 22000 (got {})",
+        "Rust stack must bind base 22000 (got {})",
         settings.port
     );
 }
 
 #[test]
-fn resolve_server_settings_keeps_ts_port_base_when_opensessions_rust_unset() {
+fn resolve_server_settings_uses_default_port_base_without_opensessions_rust() {
     let settings = resolve_server_settings(|key| match key {
         "TMUX" => Some("/private/tmp/tmux-501/os-rs-test,123,0".to_string()),
         _ => None,
@@ -64,7 +63,7 @@ fn resolve_server_settings_keeps_ts_port_base_when_opensessions_rust_unset() {
 }
 
 #[test]
-fn resolve_server_settings_explicit_port_overrides_rust_base() {
+fn resolve_server_settings_explicit_port_overrides_port_base() {
     let settings = resolve_server_settings(|key| match key {
         "TMUX" => Some("/private/tmp/tmux-501/os-rs-test,123,0".to_string()),
         "OPENSESSIONS_RUST" => Some("1".to_string()),

--- a/packages/runtime-rs/tests/config_and_shared.rs
+++ b/packages/runtime-rs/tests/config_and_shared.rs
@@ -16,6 +16,14 @@ fn server_key_hash_and_port_resolution_match_typescript() {
     assert_eq!(resolve_server_port(None, None), DEFAULT_SERVER_PORT);
     assert_eq!(resolve_server_port(Some("19916"), None), 41_916);
     assert_eq!(resolve_server_port(Some("19916"), Some("8123")), 8_123);
+    // Overflow fallback: keys that push base+key above u16::MAX (and
+    // even values that overflow the u32 checked_add) must fall back to
+    // DEFAULT_SERVER_PORT rather than silently wrap.
+    assert_eq!(resolve_server_port(Some("50000"), None), DEFAULT_SERVER_PORT);
+    assert_eq!(
+        resolve_server_port(Some("4294967295"), None),
+        DEFAULT_SERVER_PORT
+    );
 }
 
 #[test]

--- a/packages/runtime-rs/tests/config_and_shared.rs
+++ b/packages/runtime-rs/tests/config_and_shared.rs
@@ -14,7 +14,7 @@ use opensessions_runtime::shared::{
 fn server_key_hash_and_port_resolution_match_typescript() {
     assert_eq!(hash_server_key("/private/tmp/tmux-501/default"), 19_916);
     assert_eq!(resolve_server_port(None, None), DEFAULT_SERVER_PORT);
-    assert_eq!(resolve_server_port(Some("19916"), None), 36_916);
+    assert_eq!(resolve_server_port(Some("19916"), None), 41_916);
     assert_eq!(resolve_server_port(Some("19916"), Some("8123")), 8_123);
 }
 
@@ -28,16 +28,17 @@ fn resolves_server_settings_from_tmux_socket_and_env_overrides() {
 
     assert_eq!(settings.server_key.as_deref(), Some("19916"));
     assert_eq!(settings.host, "0.0.0.0");
-    assert_eq!(settings.port, 36_916);
+    assert_eq!(settings.port, 41_916);
     assert_eq!(settings.pid_file, "/tmp/opensessions.19916.pid");
 }
 
 #[test]
 fn resolve_server_settings_uses_rust_port_base_when_opensessions_rust_set() {
-    // When OPENSESSIONS_RUST=1 the Rust server stack must bind a different
-    // port range (22000+server_key) so it can coexist with the TS bun server
-    // (17000+server_key) on the same tmux socket. Mirrors the PORT_BASE
-    // branch in integrations/tmux-plugin/scripts/server-common.sh.
+    // OPENSESSIONS_RUST=1 was an opt-in toggle while the TS bun server
+    // (17000+server_key) coexisted with the Rust stack. The TS server is
+    // gone (commit 89168a3) and the Rust stack now always binds
+    // 22000+server_key (`SERVER_PORT_BASE`). The env var is still accepted
+    // for backwards-compatibility but no longer affects the port.
     let settings = resolve_server_settings(|key| match key {
         "TMUX" => Some("/private/tmp/tmux-501/os-rs-test,123,0".to_string()),
         "OPENSESSIONS_RUST" => Some("1".to_string()),
@@ -59,7 +60,7 @@ fn resolve_server_settings_keeps_ts_port_base_when_opensessions_rust_unset() {
         _ => None,
     });
 
-    assert_eq!(settings.port, 25_011);
+    assert_eq!(settings.port, 30_011);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Commit [`89168a3`](https://github.com/Ataraxy-Labs/opensessions/commit/89168a3) ("chore: remove TypeScript fallback, Rust-only runtime") pinned `integrations/tmux-plugin/scripts/server-common.sh` to `PORT_BASE=22000` and removed the `OPENSESSIONS_RUST` opt-in flag. Several call sites were missed: the TUI sidebar binary, the shared runtime helpers, the Amp/Pi TS integrations, tests, and docs all kept the legacy 17000 base.

After a fresh install, `prefix + o → s` silently fails — the server binds `22000 + server_key`, but the spawned sidebar pane connects to `ws://localhost:17000 + server_key`, gets `Connection refused`, and dies before the user sees anything.

This PR finishes the migration end-to-end and hardens the env-parsing edges to keep client and server on the same port.

## How I noticed

Fresh TPM install on macOS, `cargo build --release` succeeds, but `prefix + o → s` produces no visible output. Debug log shows the gap:

```
toggle_sidebar: spawning in session=1 window=@1 width=26
[sidebar] starting: connecting to ws://127.0.0.1:36916/ ...
```

`lsof` confirms the server is on **41916** (= 22000 + 19916 for socket `/private/tmp/tmux-501/default`). The TUI was reading the legacy 17000 base from `apps/tui-rs/src/runtime_config.rs:20`, so its WebSocket connection went to the wrong port and the pane died instantly.

A repo-wide grep for `17_000` / `17000` surfaced seven sites still on the old base.

## Changes

**Runtime — root cause**

- `apps/tui-rs/src/runtime_config.rs`: `17_000 + key` → `(SERVER_PORT_BASE + u32::from(key)) as u16` via `u16::try_from(...).unwrap_or_else(...)` so out-of-range keys fall back to `DEFAULT_SERVER_PORT` and log to stderr.
- `packages/runtime-rs/src/shared.rs`: `resolve_server_port` default base → `SERVER_PORT_BASE = 22_000`; `resolve_server_settings` drops the dead `OPENSESSIONS_RUST` branch and pins the same constant; `resolve_server_port_with_base` enforces the documented `base + key <= u16::MAX` precondition with `base.checked_add(key).and_then(|sum| u16::try_from(sum).ok()).unwrap_or_else(...)`. The doc comment is rewritten to drop the dead "OPENSESSIONS_RUST + TS bun coexist" narrative.

**Integrations**

- `integrations/amp/opensessions.ts` and `integrations/pi-extension/opensessions-runtime.ts`: 17000 → 22000 on both the `OPENSESSIONS_SERVER_KEY` and `TMUX`-hash branches.
- Strict env parsing via `const DECIMAL_INTEGER_RE = /^\+?[0-9]+$/`. `Number.parseInt` is too lenient (`"123abc"` → 123, `"0.5"` → 0); `Number()` is too permissive (`"1e3"`, `"0x10"` coerce to integers). The regex matches what Rust's `u32::from_str` / `u16::from_str` accept (decimal ASCII digits + optional leading `+`; empirically verified on `rustc 1.96.0` that `"+8123".parse::<u16>()` returns `Ok(8123)`).
- On invalid explicit `OPENSESSIONS_SERVER_KEY`, fall back to `DEFAULT_SERVER_PORT` rather than the TMUX-derived port, mirroring the Rust server's behavior on the same input so client and server resolve to the same port.

**Tests**

- `apps/tui-rs/tests/{cli,protocol}.rs`: 36916 → 41916; `protocol.rs` adds overflow fallback cases (`key=50_000` and `u16::MAX` → `DEFAULT_SERVER_PORT`).
- `packages/runtime-rs/tests/config_and_shared.rs`: 36916 → 41916, 25011 → 30011; added overflow fallback cases (`server_key="50000"`, `"4294967295"`); renamed three tests whose names referred to the dead `rust_base` / `ts_port_base` distinction; merged the redundant set/unset env-var pair into one test that asserts equality.

**Docs / comments**

- `docs/ratatui-migration/{04-protocol-and-types,11-config-and-persistence}.md`: 17000 → 22000 in examples.
- Test comment block updated to describe the historical TS bun setup in past tense.

## Test plan

- [x] `cargo test --release` — all test binaries pass.
- [x] Manual end-to-end: fresh build → restart server → press `prefix + o → s` → sidebar panes spawn in every active window, server listens on `22000 + server_key`, TUI connects to the same port, `/tmp/opensessions-err.log` stays empty across multiple toggles.

## Deferred to follow-up

- `resolve_server_port_with_base` is now only called with `SERVER_PORT_BASE` in tree, so `base: u32` is effectively dead configuration surface. Kept public — downgrading visibility is a separate API change.
- `SERVER_PORT_BASE` is duplicated in `apps/tui-rs/src/runtime_config.rs` and `packages/runtime-rs/src/shared.rs` because `tui-rs` does not depend on `runtime-rs`. Cross-reference comments document the in-sync invariant; lifting the const into a shared crate (`sidebar-protocol-rs` is the natural home, but `runtime-rs` would need a new dep on it) is out of scope here.
- The Amp and Pi TS resolvers have no in-tree test infrastructure. Adding TS test coverage is out of scope for this migration fix.
- `OPENSESSIONS_PORT` with values outside `(0, 65535]` silently falls through to the `SERVER_KEY` / TMUX branches on both Rust and TS. Surfacing that as a hard fallback to `DEFAULT_SERVER_PORT` matches the `SERVER_KEY` arm but changes existing behavior on both sides — proposed as a separate follow-up.
