### PR TITLE
fix: spawn sidebar via sh -c for non-POSIX login shells

### DIFF
--- a/packages/runtime-rs/src/tmux_provider.rs
+++ b/packages/runtime-rs/src/tmux_provider.rs
@@ -820,10 +820,16 @@ impl MuxProvider for TmuxProvider {
         // pane works even when the parent pane's cwd is unrelated to the
         // workspace (e.g. tmux sessions whose default cwd is `$HOME`). Falls
         // back to the literal path if the env is unset.
-        let command = format!(
+        //
+        // tmux runs this command through the user's `default-shell` (`$SHELL`),
+        // which may be a non-POSIX shell (e.g. fish) that can't parse
+        // `${VAR:-default}`. Wrap it in `sh -c` so the POSIX syntax is always
+        // interpreted by a POSIX shell.
+        let inner = format!(
             "OPENSESSIONS_SESSION_NAME={} OPENSESSIONS_WINDOW_ID={window_id} REFOCUS_WINDOW={window_id} exec \"${{OPENSESSIONS_DIR:-.}}\"/{scripts_dir}/start.sh",
             target.session_name,
         );
+        let command = format!("sh -c {}", shell_quote(&inner));
         let new_pane = self.client.split_sidebar_pane(
             &target.id,
             position == SidebarPosition::Left,


### PR DESCRIPTION
## Summary
- The sidebar fails to launch for users whose login shell is non-POSIX (e.g. **fish**), erroring with `fish: ${ is not a variable`.
- tmux `split-window` runs the spawn command through the user's `default-shell` (`$SHELL`), but the command string uses POSIX parameter expansion `${OPENSESSIONS_DIR:-.}`, which fish (and csh/tcsh) can't parse.
- Fix wraps the command in `sh -c` (reusing the existing `shell_quote` helper) so the POSIX syntax is always interpreted by a POSIX shell, regardless of the user's login shell.

## Changes
- `packages/runtime-rs/src/tmux_provider.rs` — `spawn_sidebar` now builds the inner command as before and passes it to `sh -c <quoted>` instead of relying on the login shell to parse `${VAR:-default}`.

## Test plan
- [ ] With `fish` (or another non-POSIX shell) as `$SHELL`, start opensessions and confirm the sidebar pane launches instead of showing `fish: ${ is not a variable`.
- [ ] With `bash`/`zsh` as `$SHELL`, confirm the sidebar still launches and `OPENSESSIONS_DIR` fallback still resolves correctly.
- [ ] `cargo build --release` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)