### PR TITLE
Install tmux hooks into a fixed array slot to coexist with other plugins

### DIFF
--- a/integrations/tmux-plugin/scripts/uninstall.sh
+++ b/integrations/tmux-plugin/scripts/uninstall.sh
@@ -13,6 +13,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 echo "opensessions: uninstalling..."
 
 # --- Remove global hooks ---
+# Hooks are installed into a fixed array slot (see HOOK_INDEX in
+# tmux_provider.rs) so they coexist with other plugins' hooks. Unset only
+# that slot, not the whole array, to avoid wiping other plugins' hooks.
+HOOK_INDEX=90210
 for hook in \
   client-session-changed \
   session-created \
@@ -23,7 +27,7 @@ for hook in \
   after-kill-pane \
   pane-exited \
   after-resize-pane; do
-  tmux set-hook -gu "$hook" 2>/dev/null || true
+  tmux set-hook -gu "${hook}[${HOOK_INDEX}]" 2>/dev/null || true
 done
 echo "  ✓ removed global hooks"
 

--- a/packages/runtime-rs/src/tmux_provider.rs
+++ b/packages/runtime-rs/src/tmux_provider.rs
@@ -13,6 +13,15 @@ use crate::tmux_scripting::{
 const SEP: &str = "\t";
 const STASH_SESSION: &str = "_os_stash";
 
+// tmux hooks are arrays. Setting a hook without an array index (e.g.
+// `set-hook -g after-select-window '...'`) REPLACES the entire array,
+// wiping any elements other plugins installed at different indices. To
+// coexist with other plugins' hooks, opensessions writes every hook into
+// its own fixed array slot and only ever touches that slot. The index is
+// arbitrary but must be distinctive enough not to collide with another
+// plugin's chosen index.
+const HOOK_INDEX: u32 = 90210;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandOutput {
     pub exit_code: i32,
@@ -396,7 +405,11 @@ impl TmuxClient {
     }
 
     pub fn set_global_hook(&self, name: &str, command: &str) {
-        let output = self.run(&["set-hook", "-g", name, command]);
+        // Write to our own array slot so we don't clobber other plugins'
+        // hooks on the same event. Re-running setup is idempotent because we
+        // always target the same index. See HOOK_INDEX.
+        let slot = format!("{name}[{HOOK_INDEX}]");
+        let output = self.run(&["set-hook", "-g", &slot, command]);
         if !output.ok() {
             eprintln!(
                 "opensessions: failed to install tmux hook {name}: status={} stderr={} command={command}",
@@ -406,7 +419,9 @@ impl TmuxClient {
     }
 
     pub fn unset_global_hook(&self, name: &str) {
-        self.run(&["set-hook", "-gu", name]);
+        // Only remove our own slot, leaving other plugins' elements intact.
+        let slot = format!("{name}[{HOOK_INDEX}]");
+        self.run(&["set-hook", "-gu", &slot]);
     }
 
     pub fn set_global_option(&self, name: &str, value: &str) {


### PR DESCRIPTION
tmux hooks are arrays. Setting a hook without an array index (e.g. `set-hook -g after-select-window '...'`) replaces the entire array, silently wiping any elements other plugins installed at different indices. Because the daemon re-runs `setup_hooks` on session events, this clobbered other plugins' hooks after they had loaded.

Route every hook through a fixed array slot (`HOOK_INDEX`) so opensessions only ever touches its own slot. This coexists with other plugins' hooks and is idempotent on re-run (overwrites the same slot rather than appending duplicates, as `set-hook -ga` would). `uninstall.sh` likewise now unsets only our slot instead of the whole array.