### PR TITLE
fix: reap closed agents from the sidebar

### DIFF
--- a/apps/server-rs/src/lib.rs
+++ b/apps/server-rs/src/lib.rs
@@ -177,7 +177,7 @@ pub trait StateSource: Send + Sync + 'static {
         Err(PiRuntimeError::InvalidPayload)
     }
 
-    fn handle_pi_runtime_delete(&self, _body: &Value) -> Result<(), PiRuntimeError> {
+    fn handle_pi_runtime_delete(&self, _body: &Value) -> Result<Option<String>, PiRuntimeError> {
         Err(PiRuntimeError::MissingPid)
     }
 
@@ -633,6 +633,9 @@ impl StateSource for ReadOnlyMuxStateSource {
     fn snapshot_json(&self) -> String {
         self.sync_agent_pane_presence();
         self.mark_focused_agent_panes_seen();
+        // Reap terminal agent entries past their TTL so closed agents drop
+        // out of the agents tab without manual dismissal.
+        self.agent_tracker.lock().unwrap().prune_terminal();
 
         let providers = self
             .providers
@@ -886,6 +889,17 @@ impl StateSource for ReadOnlyMuxStateSource {
                 }
                 None
             }
+            "dismiss-agent" => {
+                let session = command.get("session")?.as_str()?;
+                let agent = command.get("agent")?.as_str()?;
+                let thread_id = command.get("threadId").and_then(Value::as_str);
+                let dismissed = self
+                    .agent_tracker
+                    .lock()
+                    .unwrap()
+                    .dismiss(session, agent, thread_id);
+                dismissed.then(|| self.snapshot_json())
+            }
             _ => None,
         }
     }
@@ -1022,14 +1036,27 @@ impl StateSource for ReadOnlyMuxStateSource {
         Ok(())
     }
 
-    fn handle_pi_runtime_delete(&self, body: &Value) -> Result<(), PiRuntimeError> {
+    fn handle_pi_runtime_delete(&self, body: &Value) -> Result<Option<String>, PiRuntimeError> {
         let pid = body
             .get("pid")
             .and_then(Value::as_u64)
             .filter(|pid| *pid > 0 && *pid <= u32::MAX as u64)
             .ok_or(PiRuntimeError::MissingPid)? as u32;
-        self.pi_runtime_registry.lock().unwrap().delete(pid);
-        Ok(())
+        let removed = self.pi_runtime_registry.lock().unwrap().delete(pid);
+        let Some(info) = removed else {
+            return Ok(None);
+        };
+        // A clean pi exit is the authoritative "this agent is closed" signal;
+        // drop its tracker entry so the agents tab doesn't keep a ghost.
+        let dismissed = self
+            .resolve_session_for_dir(&info.cwd)
+            .is_some_and(|session| {
+                self.agent_tracker
+                    .lock()
+                    .unwrap()
+                    .dismiss(&session, "pi", Some(&info.session_id))
+            });
+        Ok(dismissed.then(|| self.snapshot_json()))
     }
 
     fn handle_http_text(&self, path: &str, body: &str) -> Option<String> {
@@ -1057,7 +1084,7 @@ impl StateSource for ReadOnlyMuxStateSource {
                     .map(|name| activate_session_json(name, None))
                     .or_else(|| spawned.then(|| self.snapshot_json()))
             }
-            "/pane-exited" => {
+            "/pane-exited" | "/pane-died" => {
                 let fallback_sessions = self
                     .providers
                     .iter()
@@ -1075,7 +1102,10 @@ impl StateSource for ReadOnlyMuxStateSource {
                 if self.is_sidebar_visible() {
                     self.enforce_sidebar_width(self.current_sidebar_width_u16());
                 }
-                None
+                // Re-sync agent pane presence and push the update immediately
+                // instead of waiting for the next poll tick (snapshot_json
+                // runs the presence sync and terminal pruning).
+                Some(self.snapshot_json())
             }
             "/pane-layout-changed" | "/client-resized" => {
                 if self.is_sidebar_visible() {
@@ -1237,35 +1267,37 @@ impl ReadOnlyMuxStateSource {
                 .map(|session| session.name.clone());
         }
 
+        self.resolve_session_for_dir(project_dir)
+    }
+
+    /// Resolve a project dir against every provider's session dirs.
+    fn resolve_session_for_dir(&self, project_dir: &str) -> Option<String> {
         let dir_session_map = build_dir_session_map(
-            sessions
-                .into_iter()
+            self.providers
+                .iter()
+                .flat_map(|provider| provider.list_sessions())
                 .map(|session| (session.name, session.dir)),
         );
         resolve_session_for_project_dir(project_dir, &dir_session_map)
     }
 
     fn resolve_agent_event_session(&self, body: &Value) -> Option<String> {
-        let sessions = self
-            .providers
-            .iter()
-            .flat_map(|provider| provider.list_sessions())
-            .collect::<Vec<_>>();
-
-        if let Some(project_dir) = body.get("projectDir").and_then(Value::as_str) {
-            let dir_session_map = build_dir_session_map(
-                sessions
-                    .iter()
-                    .map(|session| (session.name.clone(), session.dir.clone())),
-            );
-            if let Some(session) = resolve_session_for_project_dir(project_dir, &dir_session_map) {
-                return Some(session);
-            }
+        if let Some(project_dir) = body.get("projectDir").and_then(Value::as_str)
+            && let Some(session) = self.resolve_session_for_dir(project_dir)
+        {
+            return Some(session);
         }
 
         body.get("tmuxSession")
             .and_then(Value::as_str)
-            .filter(|tmux_session| sessions.iter().any(|session| session.name == *tmux_session))
+            .filter(|tmux_session| {
+                self.providers.iter().any(|provider| {
+                    provider
+                        .list_sessions()
+                        .iter()
+                        .any(|session| session.name == *tmux_session)
+                })
+            })
             .map(ToString::to_string)
     }
 
@@ -2638,21 +2670,27 @@ async fn handle_connection(
             let _ = stream.shutdown().await;
             return Ok(());
         };
-        if let Some(state_source) = &state_source
-            && let Err(err) = state_source.handle_pi_runtime_delete(&body)
-        {
-            let body = err.body();
-            stream
-                .write_all(
-                    format!(
-                        "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\n\r\n{body}",
-                        body.len()
-                    )
-                    .as_bytes(),
-                )
-                .await?;
-            let _ = stream.shutdown().await;
-            return Ok(());
+        if let Some(state_source) = &state_source {
+            match state_source.handle_pi_runtime_delete(&body) {
+                Ok(Some(payload)) => {
+                    let _ = state_updates.send(payload);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    let body = err.body();
+                    stream
+                        .write_all(
+                            format!(
+                                "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\n\r\n{body}",
+                                body.len()
+                            )
+                            .as_bytes(),
+                        )
+                        .await?;
+                    let _ = stream.shutdown().await;
+                    return Ok(());
+                }
+            }
         }
         stream
             .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
@@ -2946,7 +2984,12 @@ fn is_metadata_path(path: &str) -> bool {
 fn is_ok_hook_path(path: &str) -> bool {
     matches!(
         path,
-        "/pane-exited" | "/pane-layout-changed" | "/client-resized" | "/ensure-sidebar" | "/toggle"
+        "/pane-exited"
+            | "/pane-died"
+            | "/pane-layout-changed"
+            | "/client-resized"
+            | "/ensure-sidebar"
+            | "/toggle"
     )
 }
 
@@ -3018,4 +3061,196 @@ fn clamp_detail_panel_height(height: u16) -> u16 {
 
 fn parse_command(message: &Message) -> Option<Value> {
     serde_json::from_str::<Value>(message.as_text()?).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opensessions_runtime::mux::MuxSessionInfo;
+
+    struct FakeProvider {
+        sessions: Vec<(&'static str, &'static str)>,
+    }
+
+    impl FakeProvider {
+        fn new(sessions: Vec<(&'static str, &'static str)>) -> Arc<Self> {
+            Arc::new(Self { sessions })
+        }
+    }
+
+    impl MuxProvider for FakeProvider {
+        fn name(&self) -> &str {
+            "tmux"
+        }
+
+        fn list_sessions(&self) -> Vec<MuxSessionInfo> {
+            self.sessions
+                .iter()
+                .map(|(name, dir)| MuxSessionInfo {
+                    name: (*name).to_string(),
+                    created_at: 0,
+                    dir: (*dir).to_string(),
+                    windows: 1,
+                })
+                .collect()
+        }
+
+        fn switch_session(&self, _name: &str, _client_tty: Option<&str>) {}
+
+        fn get_current_session(&self) -> Option<String> {
+            None
+        }
+
+        fn get_session_dir(&self, name: &str) -> String {
+            self.sessions
+                .iter()
+                .find(|(session, _)| *session == name)
+                .map(|(_, dir)| (*dir).to_string())
+                .unwrap_or_default()
+        }
+
+        fn get_pane_count(&self, _name: &str) -> u32 {
+            0
+        }
+
+        fn get_client_tty(&self) -> String {
+            String::new()
+        }
+
+        fn create_session(&self, _name: Option<&str>, _dir: Option<&str>) {}
+
+        fn kill_session(&self, _name: &str) {}
+
+        fn setup_hooks(&self, _server_host: &str, _server_port: u16) {}
+
+        fn cleanup_hooks(&self) {}
+    }
+
+    struct NoPorts;
+
+    impl PortCommandRunner for NoPorts {
+        fn process_rows(&self) -> Vec<(u32, u32)> {
+            Vec::new()
+        }
+
+        fn lsof_fields(&self) -> String {
+            String::new()
+        }
+    }
+
+    struct NoGit;
+
+    impl GitCommandRunner for NoGit {
+        fn git_info_output(&self, _dir: &str) -> String {
+            String::new()
+        }
+    }
+
+    fn source_with(providers: Vec<Arc<dyn MuxProvider>>) -> ReadOnlyMuxStateSource {
+        ReadOnlyMuxStateSource::new(providers)
+            .with_port_command_runner(Arc::new(NoPorts))
+            .with_git_command_runner(Arc::new(NoGit))
+            .with_now_ms(|| 0)
+    }
+
+    #[test]
+    fn dismiss_agent_command_removes_the_tracker_entry() {
+        let source = source_with(vec![FakeProvider::new(vec![("work", "/home/u/work")])]);
+
+        source
+            .apply_agent_event(&serde_json::json!({
+                "agent": "pi",
+                "status": "running",
+                "threadId": "T-1",
+                "projectDir": "/home/u/work",
+            }))
+            .expect("event resolves to the work session");
+        assert_eq!(
+            source
+                .agent_tracker
+                .lock()
+                .unwrap()
+                .get_agents("work")
+                .len(),
+            1
+        );
+
+        let snapshot = source.handle_client_command(&serde_json::json!({
+            "type": "dismiss-agent",
+            "session": "work",
+            "agent": "pi",
+            "threadId": "T-1",
+        }));
+
+        assert!(snapshot.is_some());
+        assert!(
+            source
+                .agent_tracker
+                .lock()
+                .unwrap()
+                .get_agents("work")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn dismiss_agent_command_for_unknown_entry_is_a_no_op() {
+        let source = source_with(vec![FakeProvider::new(vec![("work", "/home/u/work")])]);
+
+        let snapshot = source.handle_client_command(&serde_json::json!({
+            "type": "dismiss-agent",
+            "session": "work",
+            "agent": "pi",
+            "threadId": "T-404",
+        }));
+
+        assert!(snapshot.is_none());
+    }
+
+    #[test]
+    fn pi_runtime_delete_dismisses_the_tracked_agent() {
+        let source = source_with(vec![FakeProvider::new(vec![("work", "/home/u/work")])]);
+
+        source
+            .handle_pi_runtime_upsert(&serde_json::json!({
+                "pid": 4242,
+                "sessionId": "S-1",
+                "cwd": "/home/u/work",
+                "ts": 1,
+            }))
+            .expect("upsert");
+        source
+            .apply_agent_event(&serde_json::json!({
+                "agent": "pi",
+                "status": "running",
+                "threadId": "S-1",
+                "projectDir": "/home/u/work",
+            }))
+            .expect("event resolves to the work session");
+
+        let snapshot = source
+            .handle_pi_runtime_delete(&serde_json::json!({ "pid": 4242 }))
+            .expect("delete succeeds");
+
+        assert!(snapshot.is_some());
+        assert!(
+            source
+                .agent_tracker
+                .lock()
+                .unwrap()
+                .get_agents("work")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn pi_runtime_delete_for_unknown_pid_is_a_no_op() {
+        let source = source_with(vec![FakeProvider::new(vec![("work", "/home/u/work")])]);
+
+        let snapshot = source
+            .handle_pi_runtime_delete(&serde_json::json!({ "pid": 999 }))
+            .expect("delete succeeds");
+
+        assert!(snapshot.is_none());
+    }
 }

--- a/packages/runtime-rs/src/agent_watchers.rs
+++ b/packages/runtime-rs/src/agent_watchers.rs
@@ -253,7 +253,7 @@ pub fn pi_snapshot_from_jsonl(
     }
 
     let idle_for = now_ms.saturating_sub(mtime_ms);
-    if status == AgentStatus::Running && idle_for >= STUCK_MS {
+    if matches!(status, AgentStatus::Running | AgentStatus::Waiting) && idle_for >= STUCK_MS {
         status = AgentStatus::Stale;
     }
 
@@ -327,7 +327,7 @@ pub fn droid_snapshot_from_jsonl(
     }
 
     let idle_for = now_ms.saturating_sub(mtime_ms);
-    if status == AgentStatus::Running && idle_for >= STUCK_MS {
+    if matches!(status, AgentStatus::Running | AgentStatus::Waiting) && idle_for >= STUCK_MS {
         status = AgentStatus::Stale;
     }
 
@@ -758,6 +758,20 @@ mod tests {
         assert_eq!(snapshot.thread_name.as_deref(), Some("Nice title"));
         assert_eq!(snapshot.last_user_prompt.as_deref(), Some("Follow up"));
         assert_eq!(snapshot.status, AgentStatus::Running);
+    }
+
+    #[test]
+    fn pi_snapshot_stales_a_waiting_thread_after_idle_timeout() {
+        let raw = r#"
+{"type":"session","version":3,"id":"pi-session","cwd":"/repo"}
+{"type":"message","id":"u1","parentId":null,"message":{"role":"user","content":[{"type":"text","text":"Task"}]}}
+{"type":"message","id":"a1","parentId":"u1","message":{"role":"assistant","content":[{"type":"text","text":"Which option?"}]}}
+"#;
+        let waiting = pi_snapshot_from_jsonl("file", raw, 1_000, 1_100).expect("snapshot");
+        assert_eq!(waiting.status, AgentStatus::Waiting);
+
+        let stale = pi_snapshot_from_jsonl("file", raw, 1_000, 1_000 + STUCK_MS).expect("snapshot");
+        assert_eq!(stale.status, AgentStatus::Stale);
     }
 
     #[test]

--- a/packages/runtime-rs/src/pi_runtime_registry.rs
+++ b/packages/runtime-rs/src/pi_runtime_registry.rs
@@ -37,8 +37,8 @@ impl PiRuntimeRegistry {
         self.by_pid.insert(info.pid, info);
     }
 
-    pub fn delete(&mut self, pid: u32) -> bool {
-        self.by_pid.remove(&pid).is_some()
+    pub fn delete(&mut self, pid: u32) -> Option<PiRuntimeInfo> {
+        self.by_pid.remove(&pid)
     }
 
     pub fn get(&mut self, pid: u32, now: u64) -> Option<PiRuntimeInfo> {

--- a/packages/runtime-rs/src/tracker.rs
+++ b/packages/runtime-rs/src/tracker.rs
@@ -4,6 +4,9 @@ use crate::protocol::{AgentEvent, AgentLiveness, AgentStatus};
 
 const MAX_EVENT_TIMESTAMPS: usize = 30;
 const TERMINAL_PRUNE_MS: u64 = 5 * 60 * 1000;
+/// Unseen terminal entries stay longer so a finished agent's notification
+/// dot isn't reaped before the user had a chance to notice it.
+const UNSEEN_TERMINAL_PRUNE_MS: u64 = 30 * 60 * 1000;
 const SYNTHETIC_PANE_MARKER: &str = ":pane:";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -218,33 +221,54 @@ impl AgentTracker {
         }
     }
 
-    pub fn prune_terminal(&mut self) {
+    /// Remove terminal-status entries (done/error/interrupted/stale) whose
+    /// pane is not known to be alive, after a TTL: `TERMINAL_PRUNE_MS` once
+    /// seen, `UNSEEN_TERMINAL_PRUNE_MS` while still unseen. Returns whether
+    /// anything was removed.
+    pub fn prune_terminal(&mut self) -> bool {
         let now = now_ms();
         let sessions = self.instances.keys().cloned().collect::<Vec<_>>();
+        let mut changed = false;
 
         for session in sessions {
             let unseen_instances = self.unseen_instances.clone();
+            let mut removed_keys = Vec::new();
             let mut empty = false;
             if let Some(session_instances) = self.instances.get_mut(&session) {
                 let keys = session_instances
                     .iter()
                     .filter(|(key, event)| {
-                        is_terminal_status(event.status)
-                            && !unseen_instances.contains(&format!("{session}\0{key}"))
-                            && event.liveness != Some(AgentLiveness::Alive)
-                            && now.saturating_sub(event.ts) > TERMINAL_PRUNE_MS
+                        if !is_terminal_status(event.status)
+                            || event.liveness == Some(AgentLiveness::Alive)
+                        {
+                            return false;
+                        }
+                        let ttl = if unseen_instances.contains(&format!("{session}\0{key}")) {
+                            UNSEEN_TERMINAL_PRUNE_MS
+                        } else {
+                            TERMINAL_PRUNE_MS
+                        };
+                        now.saturating_sub(event.ts) > ttl
                     })
                     .map(|(key, _)| key.clone())
                     .collect::<Vec<_>>();
                 for key in keys {
                     session_instances.remove(&key);
+                    removed_keys.push(key);
                 }
                 empty = session_instances.is_empty();
             }
             if empty {
                 self.instances.remove(&session);
             }
+            for key in removed_keys {
+                changed = true;
+                self.unseen_instances
+                    .remove(&self.unseen_key(&session, &key));
+            }
         }
+
+        changed
     }
 
     pub fn is_unseen(&self, session: &str) -> bool {
@@ -1219,5 +1243,69 @@ mod tests {
 
         assert!(tracker.is_unseen("work"));
         assert_eq!(tracker.get_agents("work")[0].unseen, Some(true));
+    }
+
+    fn aged_terminal_event(session: &str, thread_id: &str, age_ms: u64) -> AgentEvent {
+        let mut event = event("pi", session, Some(thread_id), None);
+        event.status = AgentStatus::Done;
+        event.ts = now_ms().saturating_sub(age_ms);
+        event
+    }
+
+    #[test]
+    fn prune_terminal_removes_seen_terminal_entries_after_ttl() {
+        let mut tracker = AgentTracker::new();
+        tracker.apply_event(aged_terminal_event("work", "T-1", TERMINAL_PRUNE_MS + 1));
+        tracker.mark_seen("work");
+
+        assert!(tracker.prune_terminal());
+        assert!(tracker.get_agents("work").is_empty());
+    }
+
+    #[test]
+    fn prune_terminal_keeps_unseen_terminal_entries_within_grace_period() {
+        let mut tracker = AgentTracker::new();
+        tracker.apply_event(aged_terminal_event("work", "T-1", TERMINAL_PRUNE_MS + 1));
+
+        assert!(!tracker.prune_terminal());
+        assert_eq!(tracker.get_agents("work").len(), 1);
+    }
+
+    #[test]
+    fn prune_terminal_removes_unseen_terminal_entries_after_extended_ttl() {
+        let mut tracker = AgentTracker::new();
+        tracker.apply_event(aged_terminal_event(
+            "work",
+            "T-1",
+            UNSEEN_TERMINAL_PRUNE_MS + 1,
+        ));
+
+        assert!(tracker.prune_terminal());
+        assert!(tracker.get_agents("work").is_empty());
+        assert!(!tracker.is_unseen("work"));
+    }
+
+    #[test]
+    fn prune_terminal_keeps_entries_with_live_panes() {
+        let mut tracker = AgentTracker::new();
+        let mut event = aged_terminal_event("work", "T-1", UNSEEN_TERMINAL_PRUNE_MS + 1);
+        event.pane_id = Some("%7".to_string());
+        event.liveness = Some(AgentLiveness::Alive);
+        tracker.apply_event(event);
+        tracker.mark_seen("work");
+
+        assert!(!tracker.prune_terminal());
+        assert_eq!(tracker.get_agents("work").len(), 1);
+    }
+
+    #[test]
+    fn prune_terminal_keeps_non_terminal_entries() {
+        let mut tracker = AgentTracker::new();
+        let mut running = event("pi", "work", Some("T-1"), None);
+        running.ts = now_ms().saturating_sub(UNSEEN_TERMINAL_PRUNE_MS + 1);
+        tracker.apply_event(running);
+
+        assert!(!tracker.prune_terminal());
+        assert_eq!(tracker.get_agents("work").len(), 1);
     }
 }


### PR DESCRIPTION
Fixes #48.

Closed agents stayed in the agents panel until a server restart because every removal path was unwired:

- **`prune_terminal` was dead code** — implemented but never called. It now runs on every snapshot: terminal entries (done/error/interrupted/stale) without a live pane expire 5 min after being seen, or 30 min while unseen (so the notification dot isn't reaped before it can be noticed). It also clears unseen markers for pruned keys.
- **`dismiss-agent` had no server handler** — the sidebar's `D` key sent the command, `handle_client_command` dropped it. Wired to `AgentTracker::dismiss` with a snapshot broadcast.
- **pi's exit signal went nowhere** — `session_shutdown` posts `/api/runtime/pi/delete`, which only mutated the write-only `PiRuntimeRegistry`. The pid is now resolved back to its session (via the registered cwd) and the tracker entry dismissed, broadcasting a fresh snapshot.
- **`/pane-exited` now broadcasts immediately** (the snapshot path re-syncs pane presence and prunes) instead of waiting for the next 2s poll tick, and the already-installed `pane-died` hook is accepted by `is_ok_hook_path` and handled identically (#48 items 2 and 3).
- **pi/droid `Waiting` threads now stale out** after 15s of file silence, matching claude/codex — an agent killed while waiting no longer freezes in a non-terminal status the reaper ignores.

`prune_stuck` stays unwired on purpose: reaping running entries by timestamp alone risks deleting agents that are mid-turn but quiet; the agent watcher already downgrades killed agents to the terminal `stale` status within ~15s, which `prune_terminal` then reaps.

Tests: 5 new tracker tests covering the TTL/liveness/unseen matrix, plus a server-side test harness (`FakeProvider`) with 4 tests for the dismiss handler and the pi-delete bridge, and a watcher test for the pi Waiting→Stale transition. `cargo test --workspace` green (tmux E2E included, one pre-existing env-dependent flake on my machine).
