### PR TITLE
fix: repair broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ For the full tmux workflow with keybindings, troubleshooting, and configuration 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Ataraxy-Labs/opensessions&type=Date)](https://star-history.com/#Ataraxy-Labs/opensessions&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Ataraxy-Labs/opensessions&type=Date)](https://star-history.dera.page/#Ataraxy-Labs/opensessions&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README no longer renders because the upstream stargazer API it depended on is restricted. This switches the chart image and its link to a working mirror so the graph displays correctly again.